### PR TITLE
Feat: i128 data implementation on data/data_store

### DIFF
--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -207,7 +207,7 @@ trait IDataStore<TContractState> {
     fn set_i128(ref self: TContractState, key: felt252, value: u128);
 
 
-    /// Delete a u256 value for the given key.
+    /// Delete a i128 value for the given key.
     /// # Arguments
     /// * `key` - The key to delete the value for.
     fn remove_i128(ref self: TContractState, key: felt252);

--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -7,11 +7,6 @@ use core::traits::Into;
 use starknet::ContractAddress;
 use satoru::market::market::Market;
 use satoru::order::order::Order;
-use core::integer::i128;
-use core::serde::Serde;
-use core::starknet::storage_access::{Store, StorageBaseAddress};
-use core::starknet::SyscallResult;
-
 
 // *************************************************************************
 //                  Interface of the `DataStore` contract.

--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -9,7 +9,7 @@ use satoru::market::market::Market;
 use satoru::order::order::Order;
 use core::integer::i128;
 use core::serde::Serde;
-use core::starknet::storage_access::{Store,StorageBaseAddress};
+use core::starknet::storage_access::{Store, StorageBaseAddress};
 use core::starknet::SyscallResult;
 
 impl I128Serde of Serde<i128> {
@@ -241,7 +241,7 @@ trait IDataStore<TContractState> {
     /// * `key` - The key to get the value for.
     /// # Returns
     /// The value for the given key.
-    fn get_int(self: @TContractState, key: felt252) -> u128;
+    fn get_i128(self: @TContractState, key: felt252) -> u128;
 
     /// Set the int value for the given key.
     /// # Arguments
@@ -249,25 +249,25 @@ trait IDataStore<TContractState> {
     /// `value` - The value to set
     /// # Return
     /// The int value for the key.
-    fn set_int(ref self: TContractState, key: felt252, value: u128);
+    fn set_i128(ref self: TContractState, key: felt252, value: u128);
 
 
     /// Delete a u256 value for the given key.
     /// # Arguments
     /// * `key` - The key to delete the value for.
-    fn remove_int(ref self: TContractState, key: felt252);
+    fn remove_i128(ref self: TContractState, key: felt252);
 
     /// Add input to existing value.
     /// # Arguments
     /// * `key` - The key to add the value to.
     /// * `value` - The value to add.
-    fn increment_int(ref self: TContractState, key: felt252, value: u128) -> u128;
+    fn increment_i128(ref self: TContractState, key: felt252, value: u128) -> u128;
 
     /// Subtract input from existing value.
     /// # Arguments
     /// * `key` - The key to subtract the value from.
     /// * `value` - The value to subtract.
-    fn decrement_int(ref self: TContractState, key: felt252, value: u128) -> u128;    
+    fn decrement_i128(ref self: TContractState, key: felt252, value: u128) -> u128;
 }
 
 #[starknet::contract]
@@ -458,28 +458,29 @@ mod DataStore {
             new_value
         }
 
+        //TODO: Update u128 to i128 when Serde and Store for i128 implementations are released.
         // *************************************************************************
         //                      i128 related functions.
         // *************************************************************************
-        fn get_int(self: @ContractState, key: felt252) -> u128 {
+        fn get_i128(self: @ContractState, key: felt252) -> u128 {
             self.i128_values.read(key)
         }
 
-        fn set_int(ref self: ContractState, key: felt252, value: u128) {
+        fn set_i128(ref self: ContractState, key: felt252, value: u128) {
             // Check that the caller has permission to set the value.
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             // Set the value.
             self.i128_values.write(key, value);
-        }        
+        }
 
-        fn remove_int(ref self: ContractState, key: felt252) {
+        fn remove_i128(ref self: ContractState, key: felt252) {
             // Check that the caller has permission to delete the value.
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             // Delete the value.
             self.i128_values.write(key, Default::default());
         }
 
-        fn increment_int(ref self: ContractState, key: felt252, value: u128) -> u128 {
+        fn increment_i128(ref self: ContractState, key: felt252, value: u128) -> u128 {
             // Check that the caller has permission to set the value.
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             // Get the current value.
@@ -493,7 +494,7 @@ mod DataStore {
             new_value
         }
 
-        fn decrement_int(ref self: ContractState, key: felt252, value: u128) -> u128 {
+        fn decrement_i128(ref self: ContractState, key: felt252, value: u128) -> u128 {
             // Check that the caller has permission to set the value.
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             // Get the current value.
@@ -504,7 +505,7 @@ mod DataStore {
             self.i128_values.write(key, new_value);
             // Return the new value.
             new_value
-        }        
+        }
 
         // *************************************************************************
         //                      Address related functions.

--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -12,46 +12,6 @@ use core::serde::Serde;
 use core::starknet::storage_access::{Store, StorageBaseAddress};
 use core::starknet::SyscallResult;
 
-impl I128Serde of Serde<i128> {
-    fn serialize(self: @i128, ref output: Array<felt252>) {
-        Into::<i128, felt252>::into(*self).serialize(ref output);
-    }
-    fn deserialize(ref serialized: Span<felt252>) -> Option<i128> {
-        Option::Some(((*serialized.pop_front()?).try_into())?)
-    }
-}
-
-impl StoreI128 of Store<i128> {
-    fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<i128> {
-        Result::Ok(
-            Store::<felt252>::read(address_domain, base)?.try_into().expect('StoreI128 - non i128')
-        )
-    }
-    #[inline(always)]
-    fn write(address_domain: u32, base: StorageBaseAddress, value: i128) -> SyscallResult<()> {
-        Store::<felt252>::write(address_domain, base, value.into())
-    }
-    #[inline(always)]
-    fn read_at_offset(
-        address_domain: u32, base: StorageBaseAddress, offset: u8
-    ) -> SyscallResult<i128> {
-        Result::Ok(
-            Store::<felt252>::read_at_offset(address_domain, base, offset)?
-                .try_into()
-                .expect('StoreI128 - non i128')
-        )
-    }
-    #[inline(always)]
-    fn write_at_offset(
-        address_domain: u32, base: StorageBaseAddress, offset: u8, value: i128
-    ) -> SyscallResult<()> {
-        Store::<felt252>::write_at_offset(address_domain, base, offset, value.into())
-    }
-    #[inline(always)]
-    fn size() -> u8 {
-        1_u8
-    }
-}
 
 // *************************************************************************
 //                  Interface of the `DataStore` contract.

--- a/tests/data/test_data_store.cairo
+++ b/tests/data/test_data_store.cairo
@@ -130,6 +130,50 @@ fn given_normal_conditions_when_u256_functions_then_expected_results() {
 }
 
 #[test]
+fn given_normal_conditions_when_i128_functions_then_expected_results() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (caller_address, role_store, data_store) = setup();
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Set key 1 to value 42.
+    data_store.set_i128(1, 42).unwrap();
+    let value = data_store.get_i128(1).unwrap();
+    // Check that the value read is 42.
+    assert(value == 42, 'Invalid value');
+
+    // Increment key 1 by 5.
+    let new_value = data_store.increment_i128(1, 5).unwrap();
+    // Check that the new value is 47.
+    assert(new_value == 47, 'Invalid value');
+    let value = data_store.get_i128(1).unwrap();
+    // Check that the value read is 47.
+    assert(value == 47, 'Invalid value');
+
+    // Decrement key 1 by 2.
+    let new_value = data_store.decrement_i128(1, 2).unwrap();
+    // Check that the new value is 45.
+    assert(new_value == 45, 'Invalid value');
+    let value = data_store.get_i128(1).unwrap();
+    // Check that the value read is 45.
+    assert(value == 45, 'Invalid value');
+
+    // Remove key 1.
+    data_store.remove_i128(1).unwrap();
+    // Check that the key was removed.
+    assert(data_store.get_i128(1).unwrap() == Default::default(), 'Key was not deleted');
+
+    // *********************************************************************************************
+    // *                              TEARDOWN                                                     *
+    // *********************************************************************************************
+    teardown(data_store.contract_address);
+}
+
+#[test]
 fn given_normal_conditions_when_address_functions_then_expected_results() {
     // *********************************************************************************************
     // *                              SETUP                                                        *


### PR DESCRIPTION
Implemented i128 data type at src/data/data_store

Currently using u128 as Serde and Store implementation for i128 has not been released yet.

**Issue created for updating u128 to i128 when Serde and Store for i128 is released:**

https://github.com/keep-starknet-strange/satoru/issues/257

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #59

## What is the new behavior?

- data_store , get , remove, increment and decrement for i128


## Does this introduce a breaking change?

No

## Other information

None
