### PR TITLE
feat: u128 mask

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -20,6 +20,7 @@ sierra-replace-ids = true
 [dependencies]
 starknet = ">=2.1.0"
 alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria.git" }
+alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git" }
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.5.0" }
 
 

--- a/src/oracle/oracle.cairo
+++ b/src/oracle/oracle.cairo
@@ -20,7 +20,6 @@ use satoru::oracle::{
     oracle_store::{IOracleStoreDispatcher, IOracleStoreDispatcherTrait},
     oracle_utils::{SetPricesParams, ReportInfo}, error::OracleError,
 };
-use satoru::utils::u128_mask::Mask;
 use satoru::price::price::Price;
 
 // *************************************************************************
@@ -176,9 +175,9 @@ struct SetPricesInnerCache {
     /// The max prices.
     max_prices: Array<u128>,
     /// The min price index using U128Mask.
-    min_price_index_mask: Mask,
+    min_price_index_mask: u128,
     /// The max price index using U128Mask.
-    max_price_index_mask: Mask,
+    max_price_index_mask: u128,
 }
 
 #[starknet::contract]

--- a/src/utils/error.cairo
+++ b/src/utils/error.cairo
@@ -4,4 +4,6 @@ mod ReentrancyGuardError {
 mod UtilsError {
     const NULL_ACCOUNT: felt252 = 'null_account';
     const NULL_RECEIVER: felt252 = 'null_receiver';
+    const MASK_OUT_OF_BOUNDS:felt252 = 'mask index out of bounds';
+    const MASK_INDEX_NOT_UNIQUE:felt252 = 'mask index not unique';
 }

--- a/src/utils/error.cairo
+++ b/src/utils/error.cairo
@@ -4,6 +4,6 @@ mod ReentrancyGuardError {
 mod UtilsError {
     const NULL_ACCOUNT: felt252 = 'null_account';
     const NULL_RECEIVER: felt252 = 'null_receiver';
-    const MASK_OUT_OF_BOUNDS:felt252 = 'mask index out of bounds';
-    const MASK_INDEX_NOT_UNIQUE:felt252 = 'mask index not unique';
+    const MASK_OUT_OF_BOUNDS: felt252 = 'mask index out of bounds';
+    const MASK_INDEX_NOT_UNIQUE: felt252 = 'mask index not unique';
 }

--- a/src/utils/u128_mask.cairo
+++ b/src/utils/u128_mask.cairo
@@ -1,12 +1,21 @@
 // *************************************************************************
 //                                  IMPORTS
 // *************************************************************************
+use satoru::utils::error::UtilsError;
+use alexandria_math::BitShift;
 // Core lib imports.
 
-struct Mask {
-    bits: u128,
-}
-
 /// Validate that the index is unique.
-fn validate_unique_and_set_index(mask: u128, index: u128, label: felt252) { // TODO
+fn validate_unique_and_set_index(ref mask: u128, index: u128) {
+    if index >= 256 {
+        panic_with_felt252(UtilsError::MASK_OUT_OF_BOUNDS);
+    }
+
+    let bit: u128 = BitShift::shl(1, index);
+
+    if mask & bit != 0 {
+        panic_with_felt252(UtilsError::MASK_INDEX_NOT_UNIQUE);
+    }
+
+    mask = mask | bit;
 }

--- a/src/utils/u128_mask.cairo
+++ b/src/utils/u128_mask.cairo
@@ -7,7 +7,7 @@ use alexandria_math::BitShift;
 
 /// Validate that the index is unique.
 fn validate_unique_and_set_index(ref mask: u128, index: u128) {
-    if index >= 256 {
+    if index >= 128 {
         panic_with_felt252(UtilsError::MASK_OUT_OF_BOUNDS);
     }
 

--- a/tests/utils/test_u128_mask.cairo
+++ b/tests/utils/test_u128_mask.cairo
@@ -20,7 +20,7 @@ fn test_valid_index_bit_already_set() {
 #[should_panic(expected: ('mask index out of bounds',))]
 fn test_invalid_index() {
     let mut mask = 0b0000_0000;
-    validate_unique_and_set_index(ref mask, 260);
+    validate_unique_and_set_index(ref mask, 128);
 }
 
 #[test]

--- a/tests/utils/test_u128_mask.cairo
+++ b/tests/utils/test_u128_mask.cairo
@@ -1,0 +1,38 @@
+use satoru::utils::u128_mask::validate_unique_and_set_index;
+use integer::BoundedInt;
+
+
+#[test]
+fn test_valid_index_bit_not_set() {
+    let mut mask = 0b0000_0000;
+    validate_unique_and_set_index(ref mask, 3);
+    assert(mask == 0b0000_1000, 'mask not set');
+}
+
+#[test]
+#[should_panic(expected: ('mask index not unique',))]
+fn test_valid_index_bit_already_set() {
+    let mut mask = 0b0000_1000;
+    validate_unique_and_set_index(ref mask, 3);
+}
+
+#[test]
+#[should_panic(expected: ('mask index out of bounds',))]
+fn test_invalid_index() {
+    let mut mask = 0b0000_0000;
+    validate_unique_and_set_index(ref mask, 260);
+}
+
+#[test]
+fn test_edge_case_lowest_index() {
+    let mut mask = 0b0000_0000;
+    validate_unique_and_set_index(ref mask, 0);
+    assert(mask == 0b0000_0001, 'mask not set');
+}
+
+#[test]
+fn test_edge_case_highest_index() {
+    let mut mask = 0b1111_1111;
+    validate_unique_and_set_index(ref mask, 127);
+    assert(mask == 0x800000000000000000000000000000ff, 'highest bit not set')
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Implements the `fn validate_unique_and_set_index(mask: u128, index: u128, label: felt252)` in the u128Mask library

Note: This differs a bit from the GMX implementation, we use a 128-bits wide mask only.

The initial implementation states:

```rust
// since minPrices, maxPrices have the same length as the signers array
                // and the signers array length is less than MAX_SIGNERS
                // minPriceIndexMask and maxPriceIndexMask should be able to store the indexes
                // using Uint256Mask
```

And `MAX_SIGNERS =  256 / SIGNER_INDEX_LENGTH - 1;` where `SIGNER_INDEX_LENGTH = 16;` so it should fit in 128 bits anyways
# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- [x] Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build-related changes
- Documentation content changes
- Testing
- Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #246 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Implemented and tested `validate_unique_and_set_index`
- Modified the function signature to remove the `label` parameters, given that we can't have dynamic error messages (yet?)
-

## Does this introduce a breaking change?
No
<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
