### PR TITLE
Add Implementation for adl_handler Functions

### DIFF
--- a/src/adl/adl_utils.cairo
+++ b/src/adl/adl_utils.cairo
@@ -99,7 +99,7 @@ fn validate_adl(
     data_store: IDataStoreSafeDispatcher,
     market: ContractAddress,
     is_long: bool,
-    max_oracle_block_numbers: Span<u128>
+    max_oracle_block_numbers: Span<u64>
 ) { // TODO
 }
 

--- a/src/exchange/adl_handler.cairo
+++ b/src/exchange/adl_handler.cairo
@@ -43,8 +43,11 @@ trait IAdlHandler<TContractState> {
     /// before performing adl.
     fn execute_adl(
         ref self: TContractState,
-        market: ContractAddress,
+        account: ContractAddress,
+        market_address: ContractAddress,
+        collateral_token: ContractAddress,
         is_long: bool,
+        size_delta_usd: u128,
         oracle_params: SetPricesParams
     );
 }
@@ -56,33 +59,45 @@ mod AdlHandler {
     // *************************************************************************
 
     // Core lib imports.
-    use starknet::ContractAddress;
+    use starknet::{ContractAddress, get_caller_address, get_contract_address, SyscallResultTrait};
 
 
     // Local imports.
     use super::IAdlHandler;
-    use satoru::role::role_store::{IRoleStoreSafeDispatcher, IRoleStoreSafeDispatcherTrait};
-    use satoru::data::data_store::{IDataStoreSafeDispatcher, IDataStoreSafeDispatcherTrait};
+    use satoru::adl::adl_utils;
+    use satoru::exchange::base_order_handler::{
+        IBaseOrderHandlerSafeDispatcher, IBaseOrderHandlerSafeDispatcherTrait
+    };
+    use satoru::chain::chain::{IChainSafeDispatcher, IChainSafeDispatcherTrait};
+    use satoru::data::{keys, data_store::{IDataStoreSafeDispatcher, IDataStoreSafeDispatcherTrait}};
     use satoru::event::event_emitter::{
         IEventEmitterSafeDispatcher, IEventEmitterSafeDispatcherTrait
     };
+    use satoru::exchange::base_order_handler::{IBaseOrderHandler, BaseOrderHandler};
+    use satoru::exchange::base_order_handler::BaseOrderHandler::{
+        data_store::InternalContractMemberStateTrait as DataStoreStateTrait,
+        event_emitter::InternalContractMemberStateTrait as EventEmitterStateTrait,
+        oracle::InternalContractMemberStateTrait as OracleStateTrait,
+        InternalTrait as BaseOrderHandleInternalTrait,
+    };
+    use satoru::feature::feature_utils;
+    use satoru::market::{market::Market, market_utils};
+
     use satoru::oracle::{
         oracle::{IOracleSafeDispatcher, IOracleSafeDispatcherTrait},
-        oracle_modules::{with_oracle_prices_before, with_oracle_prices_after},
-        oracle_utils::SetPricesParams
+        oracle_modules::{with_oracle_prices_before, with_oracle_prices_after}, oracle_utils
     };
     use satoru::order::{
         order::{SecondaryOrderType, OrderType, Order},
         order_vault::{IOrderVaultSafeDispatcher, IOrderVaultSafeDispatcherTrait},
-        base_order_utils::{ExecuteOrderParams, ExecuteOrderParamsContracts}
+        base_order_utils::{ExecuteOrderParams, ExecuteOrderParamsContracts}, order_utils
     };
+    use satoru::role::role_store::{IRoleStoreSafeDispatcher, IRoleStoreSafeDispatcherTrait};
     use satoru::swap::swap_handler::{ISwapHandlerSafeDispatcher, ISwapHandlerSafeDispatcherTrait};
-    use satoru::market::market::Market;
-    use satoru::exchange::base_order_handler::{IBaseOrderHandler, BaseOrderHandler};
     use satoru::utils::store_arrays::StoreU64Array;
 
     /// ExecuteAdlCache struct used in execute_adl.
-    #[derive(Drop, starknet::Store, Serde)]
+    #[derive(Drop, Serde)]
     struct ExecuteAdlCache {
         /// The starting gas to execute adl.
         starting_gas: u128,
@@ -110,6 +125,7 @@ mod AdlHandler {
     #[storage]
     struct Storage {}
 
+
     // *************************************************************************
     //                              CONSTRUCTOR
     // *************************************************************************
@@ -131,7 +147,8 @@ mod AdlHandler {
         order_vault_address: ContractAddress,
         oracle_address: ContractAddress,
         swap_handler_address: ContractAddress,
-        referral_storage_address: ContractAddress
+        referral_storage_address: ContractAddress,
+        order_handler_address: ContractAddress
     ) {
         let mut state: BaseOrderHandler::ContractState =
             BaseOrderHandler::unsafe_new_contract_state();
@@ -147,7 +164,6 @@ mod AdlHandler {
         );
     }
 
-
     // *************************************************************************
     //                          EXTERNAL FUNCTIONS
     // *************************************************************************
@@ -157,16 +173,128 @@ mod AdlHandler {
             ref self: ContractState,
             market: ContractAddress,
             is_long: bool,
-            oracle_params: SetPricesParams
-        ) { // TODO
+            oracle_params: oracle_utils::SetPricesParams
+        ) {
+            let mut base_order_handler_state: BaseOrderHandler::ContractState =
+                BaseOrderHandler::unsafe_new_contract_state();
+
+            let max_oracle_block_numbers = oracle_utils::get_uncompacted_oracle_block_numbers(
+                @oracle_params.compacted_max_oracle_block_numbers, @oracle_params.tokens.len()
+            );
+            adl_utils::update_adl_state(
+                base_order_handler_state.data_store.read(),
+                base_order_handler_state.event_emitter.read(),
+                base_order_handler_state.oracle.read(),
+                market,
+                is_long,
+                max_oracle_block_numbers.span(),
+            );
         }
 
         fn execute_adl(
             ref self: ContractState,
-            market: ContractAddress,
+            account: ContractAddress,
+            market_address: ContractAddress,
+            collateral_token: ContractAddress,
             is_long: bool,
-            oracle_params: SetPricesParams
-        ) { // TODO
+            size_delta_usd: u128,
+            oracle_params: oracle_utils::SetPricesParams
+        ) {
+            let mut cache = ExecuteAdlCache {
+                starting_gas: 0,
+                min_oracle_block_numbers: array![],
+                max_oracle_block_numbers: array![],
+                key: 0,
+                should_allow_adl: false,
+                max_pnl_factor_for_adl: 0,
+                pnl_to_pool_factor: 0,
+                next_pnl_to_pool_factor: 0,
+                min_pnl_factor_for_adl: 0
+            };
+
+            cache
+                .min_oracle_block_numbers =
+                    oracle_utils::get_uncompacted_oracle_block_numbers(
+                        @oracle_params.compacted_min_oracle_block_numbers,
+                        @oracle_params.tokens.len()
+                    );
+
+            cache
+                .max_oracle_block_numbers =
+                    oracle_utils::get_uncompacted_oracle_block_numbers(
+                        @oracle_params.compacted_min_oracle_block_numbers,
+                        @oracle_params.tokens.len()
+                    );
+
+            let mut base_order_handler_state: BaseOrderHandler::ContractState =
+                BaseOrderHandler::unsafe_new_contract_state();
+
+            let data_store = base_order_handler_state.data_store.read();
+            let oracle = base_order_handler_state.oracle.read();
+
+            adl_utils::validate_adl(
+                data_store, market_address, is_long, cache.max_oracle_block_numbers.span()
+            );
+
+            let (should_allow_adl, pnl_to_pool_factor, max_pnl_factor_for_adl) =
+                market_utils::is_pnl_factor_exceeded(
+                data_store, oracle, market_address, is_long, keys::max_pnl_factor_for_adl()
+            );
+            cache.should_allow_adl = should_allow_adl;
+            cache.pnl_to_pool_factor = pnl_to_pool_factor;
+            cache.max_pnl_factor_for_adl = max_pnl_factor_for_adl;
+
+            assert(cache.should_allow_adl, 'adl not required');
+
+            cache
+                .key =
+                    adl_utils::create_adl_order(
+                        adl_utils::CreateAdlOrderParams {
+                            data_store,
+                            event_emitter: base_order_handler_state.event_emitter.read(),
+                            account,
+                            market: market_address,
+                            collateral_token,
+                            is_long,
+                            size_delta_usd,
+                            updated_at_block: (*cache.min_oracle_block_numbers.at(0))
+                        }
+                    );
+
+            let params: ExecuteOrderParams = BaseOrderHandleInternalTrait::get_execute_order_params(
+                ref base_order_handler_state,
+                cache.key,
+                oracle_params,
+                get_caller_address(),
+                cache.starting_gas,
+                SecondaryOrderType::Adl(())
+            );
+
+            // let order_type: felt252 = params.order.order_type.into();
+            feature_utils::validate_feature(
+                params.contracts.data_store,
+                keys::execute_adl_feature_disabled_key(
+                    get_contract_address(), params.order.order_type.into()
+                )
+            );
+
+            order_utils::execute_order(params);
+
+            // validate that the ratio of pending pnl to pool value was decreased
+            cache
+                .next_pnl_to_pool_factor =
+                    market_utils::get_pnl_to_pool_factor(
+                        data_store, oracle, market_address, is_long, true
+                    );
+            assert(cache.next_pnl_to_pool_factor >= cache.pnl_to_pool_factor, 'invalid adl');
+
+            cache
+                .min_pnl_factor_for_adl =
+                    market_utils::get_min_pnl_factor_after_adl(data_store, market_address, is_long);
+            assert(
+                cache.next_pnl_to_pool_factor > cache.min_pnl_factor_for_adl, 'pnl overcorrected'
+            );
         }
     }
 }
+

--- a/src/exchange/base_order_handler.cairo
+++ b/src/exchange/base_order_handler.cairo
@@ -8,6 +8,9 @@
 use core::traits::Into;
 use starknet::ContractAddress;
 
+use satoru::oracle::oracle_utils::SetPricesParams;
+use satoru::order::{order::SecondaryOrderType, base_order_utils::ExecuteOrderParams};
+
 // *************************************************************************
 //                  Interface of the `BaseOrderHandler` contract.
 // *************************************************************************

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -157,6 +157,7 @@ mod oracle {
 // `order` contains order management functions.
 mod order {
     mod base_order_utils;
+    mod order_utils;
     mod order_vault;
     mod order;
 }

--- a/src/market/market_utils.cairo
+++ b/src/market/market_utils.cairo
@@ -15,6 +15,7 @@ use satoru::event::event_emitter::{IEventEmitterSafeDispatcher, IEventEmitterSaf
 use satoru::data::keys;
 use satoru::market::error::MarketError;
 use satoru::market::market::Market;
+use satoru::oracle::oracle::{IOracleSafeDispatcher, IOracleSafeDispatcherTrait};
 use satoru::price::price::{Price, PriceTrait};
 
 /// Struct to store the prices of tokens of a market.
@@ -485,4 +486,55 @@ fn validate_open_interest(data_store: IDataStoreSafeDispatcher, market: @Market,
 
     // Check that the open interest is not greater than the maximum open interest.
     assert(open_interest <= max_open_interest, MarketError::MAX_OPEN_INTEREST_EXCEEDED);
+}
+
+// Get the min pnl factor after ADL
+// Parameters
+// * `data_store` - - The data store to use.
+// * `market` - the market to check.
+// * `is_long` whether to check the long or short side.
+fn get_min_pnl_factor_after_adl(
+    data_store: IDataStoreSafeDispatcher, market: ContractAddress, is_long: bool
+) -> u128 {
+    // TODO
+    0
+}
+
+// Get the ratio of pnl to pool value.
+// # Arguments
+// * `data_store` - The data_store dispatcher.
+// * `market` the market values.
+// * `prices` the prices of the market tokens.
+// * `is_long` whether to get the value for the long or short side.
+// * `maximize` whether to maximize the factor.
+// # Returns
+// (pnl of positions) / (long or short pool value)
+fn get_pnl_to_pool_factor(
+    data_store: IDataStoreSafeDispatcher,
+    oracle: IOracleSafeDispatcher,
+    market: ContractAddress,
+    is_long: bool,
+    maximize: bool
+) -> u128 {
+    // TODO
+    0
+}
+
+// Check if the pending pnl exceeds the allowed amount
+// # Arguments
+// * `data_store` - The data_store dispatcher.
+// * `oracle` - The oracle dispatcher.
+// * `market` - The market to check.
+// * `prices` - The prices of the market tokens.
+// * `is_long` - Whether to check the long or short side.
+// * `pnl_factor_type` - The pnl factor type to check.
+fn is_pnl_factor_exceeded(
+    data_store: IDataStoreSafeDispatcher,
+    oracle: IOracleSafeDispatcher,
+    market_address: ContractAddress,
+    is_long: bool,
+    pnl_factor_type: felt252
+) -> (bool, u128, u128) {
+    // TODO
+    (true, 0, 0)
 }

--- a/src/oracle/oracle_utils.cairo
+++ b/src/oracle/oracle_utils.cairo
@@ -30,12 +30,12 @@ use satoru::utils::store_arrays::{
 /// * `compacted_max_prices_indexes` - compacted max price indexes.
 /// * `signatures` - signatures of the oracle signers.
 /// * `price_feed_tokens` - tokens to set prices for based on an external price feed value.
-#[derive(Drop, starknet::Store, Serde)]
+#[derive(Drop, Serde)]
 struct SetPricesParams {
     signer_info: u128,
     tokens: Array<ContractAddress>,
-    compacted_min_oracle_block_numbers: Array<u128>,
-    compacted_max_oracle_block_numbers: Array<u128>,
+    compacted_min_oracle_block_numbers: Array<u64>,
+    compacted_max_oracle_block_numbers: Array<u64>,
     compacted_oracle_timestamps: Array<u128>,
     compacted_decimals: Array<u128>,
     compacted_min_prices: Array<u128>,
@@ -140,8 +140,8 @@ fn get_uncompacted_price_index(compacted_price_indexes: Array<u128>, index: u128
 /// # Returns
 /// The uncompacted oracle block numbers.
 fn get_uncompacted_oracle_block_numbers(
-    compacted_oracle_block_numbers: Array<u128>, length: u128
-) -> Array<u128> {
+    compacted_oracle_block_numbers: @Array<u64>, length: @usize
+) -> Array<u64> {
     // TODO
     ArrayTrait::new()
 }
@@ -153,8 +153,8 @@ fn get_uncompacted_oracle_block_numbers(
 /// # Returns
 /// The uncompacted oracle block number.
 fn get_uncompacted_oracle_block_number(
-    compacted_oracle_block_numbers: Array<u128>, index: u128
-) -> u128 {
+    compacted_oracle_block_numbers: Array<u64>, index: usize
+) -> u64 {
     // TODO
     0
 }

--- a/src/order/order.cairo
+++ b/src/order/order.cairo
@@ -62,7 +62,7 @@ impl OrderImpl of OrderTrait {
     }
 }
 
-#[derive(Drop, starknet::Store, Serde)]
+#[derive(Copy, Drop, starknet::Store, Serde)]
 enum OrderType {
     ///  MarketSwap: swap token A to token B at the current market price.
     /// The order will be cancelled if the minOutputAmount cannot be fulfilled.
@@ -118,6 +118,21 @@ impl DecreasePositionSwapTypePrintImpl of PrintTrait<DecreasePositionSwapType> {
                 .print(),
             DecreasePositionSwapType::SwapCollateralTokenToPnlToken => 'SwapCollateralTokenToPnlToken'
                 .print(),
+        }
+    }
+}
+
+impl OrderTypeInto of Into<OrderType, felt252> {
+    fn into(self: OrderType) -> felt252 {
+        match self {
+            OrderType::MarketSwap => 'MarketSwap',
+            OrderType::LimitSwap => 'LimitSwap',
+            OrderType::MarketIncrease => 'MarketIncrease',
+            OrderType::LimitIncrease => 'LimitIncrease',
+            OrderType::MarketDecrease => 'MarketDecrease',
+            OrderType::LimitDecrease => 'LimitDecrease',
+            OrderType::StopLossDecrease => 'StopLossDecrease',
+            OrderType::Liquidation => 'Liquidation',
         }
     }
 }

--- a/src/order/order_utils.cairo
+++ b/src/order/order_utils.cairo
@@ -1,0 +1,3 @@
+use satoru::order::base_order_utils::ExecuteOrderParams;
+
+fn execute_order(params: ExecuteOrderParams) {}


### PR DESCRIPTION
## Pull Request Type
- Feature

Closes: #275

## Breaking Change?
No

## Additional Details
Temporarily made `fn get_execute_order_params()` public in `base_order_handler.cairo`. Open to alternatives for closer alignment with Solidity.

**EDIT**
The issue mentioned in the additional details has been resolved.
