### PR TITLE
Feat/add order events tests

### DIFF
--- a/src/event/event_emitter.cairo
+++ b/src/event/event_emitter.cairo
@@ -17,6 +17,7 @@ use satoru::price::price::Price;
 use satoru::pricing::position_pricing_utils::PositionFees;
 use satoru::order::order::{Order, SecondaryOrderType};
 
+//TODO: OrderCollatDeltaAmountAutoUpdtd must be renamed back to OrderCollateralDeltaAmountAutoUpdated when string will be allowed as event argument
 
 // *************************************************************************
 //                  Interface of the `EventEmitter` contract.
@@ -237,7 +238,7 @@ trait IEventEmitter<TContractState> {
         ref self: TContractState, key: felt252, size_delta_usd: u128, next_size_delta_usd: u128
     );
 
-    /// Emits the `OrderCollateralDeltaAmountAutoUpdated` event.
+    /// Emits the `OrderCollatDeltaAmountAutoUpdtd` event.
     fn emit_order_collateral_delta_amount_auto_updated(
         ref self: TContractState,
         key: felt252,
@@ -330,7 +331,7 @@ mod EventEmitter {
         OrderExecuted: OrderExecuted,
         OrderUpdated: OrderUpdated,
         OrderSizeDeltaAutoUpdated: OrderSizeDeltaAutoUpdated,
-        OrderCollateralDeltaAmountAutoUpdated: OrderCollateralDeltaAmountAutoUpdated,
+        OrderCollatDeltaAmountAutoUpdtd: OrderCollatDeltaAmountAutoUpdtd,
         OrderCancelled: OrderCancelled,
         OrderFrozen: OrderFrozen,
         PositionIncrease: PositionIncrease,
@@ -680,7 +681,7 @@ mod EventEmitter {
     }
 
     #[derive(Drop, starknet::Event)]
-    struct OrderCollateralDeltaAmountAutoUpdated {
+    struct OrderCollatDeltaAmountAutoUpdtd {
         key: felt252,
         collateral_delta_amount: u128,
         next_collateral_delta_amount: u128
@@ -1081,7 +1082,7 @@ mod EventEmitter {
             self.emit(OrderSizeDeltaAutoUpdated { key, size_delta_usd, next_size_delta_usd });
         }
 
-        /// Emits the `OrderCollateralDeltaAmountAutoUpdated` event.
+        /// Emits the `OrderCollatDeltaAmountAutoUpdtd` event.
         fn emit_order_collateral_delta_amount_auto_updated(
             ref self: ContractState,
             key: felt252,
@@ -1090,7 +1091,7 @@ mod EventEmitter {
         ) {
             self
                 .emit(
-                    OrderCollateralDeltaAmountAutoUpdated {
+                    OrderCollatDeltaAmountAutoUpdtd {
                         key, collateral_delta_amount, next_collateral_delta_amount
                     }
                 );

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -262,6 +262,43 @@ fn test_emit_order_cancelled() {
     assert(spy.events.len() == 0, 'There should be no events');
 }
 
+#[test]
+fn test_emit_order_frozen() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (contract_address, event_emitter) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Create dummy data.
+    let key = 100;
+    let reason = 'frozen';
+    let reason_bytes = array!['0x00', '0x01'];
+
+    // Create the expected data.
+    let mut expected_data: Array<felt252> = array![key, reason.into()];
+    reason_bytes.serialize(ref expected_data);
+
+    // Emit the event.
+    event_emitter.emit_order_frozen(key, reason, reason_bytes);
+
+    // Assert the event was emitted.
+    spy
+        .assert_emitted(
+            @array![
+                Event {
+                    from: contract_address, name: 'OrderFrozen', keys: array![], data: expected_data
+                }
+            ]
+        );
+    // Assert there are no more events.
+    assert(spy.events.len() == 0, 'There should be no events');
+}
+
 
 /// Utility function to setup the test environment.
 ///

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -1,0 +1,90 @@
+use starknet::{ContractAddress, contract_address_const};
+use snforge_std::{
+    declare, ContractClassTrait, spy_events, SpyOn, EventSpy, EventFetcher, event_name_hash, Event,
+    EventAssertions
+};
+
+use satoru::event::event_emitter::{IEventEmitterSafeDispatcher, IEventEmitterSafeDispatcherTrait};
+use satoru::order::order::{Order, OrderType};
+
+#[test]
+fn test_emit_order_created() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (contract_address, event_emitter) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Create a dummy data.
+    let key: felt252 = 100;
+    let order: Order = create_dummy_order();
+
+    // Create the expected data.
+    let mut expected_data: Array<felt252> = array![key];
+    order.serialize(ref expected_data);
+
+    // Emit the event.
+    event_emitter.emit_order_created(key, order);
+
+    // Assert the event was emitted.
+    spy
+        .assert_emitted(
+            @array![
+                Event {
+                    from: contract_address,
+                    name: 'OrderCreated',
+                    keys: array![],
+                    data: expected_data
+                }
+            ]
+        );
+    // Assert there are no more events.
+    assert(spy.events.len() == 0, 'There should be no events');
+}
+
+
+/// Utility function to setup the test environment.
+///
+/// # Returns
+///
+/// * `ContractAddress` - The address of the event emitter contract.
+/// * `IEventEmitterSafeDispatcher` - The event emitter store dispatcher.
+fn setup() -> (ContractAddress, IEventEmitterSafeDispatcher) {
+    let contract = declare('EventEmitter');
+    let contract_address = contract.deploy(@array![]).unwrap();
+    let event_emitter = IEventEmitterSafeDispatcher { contract_address };
+    return (contract_address, event_emitter);
+}
+
+
+/// Utility function to create a dummy order.
+fn create_dummy_order() -> Order {
+    let mut swap_path = array![];
+    swap_path.append(contract_address_const::<'swap_path_0'>());
+    swap_path.append(contract_address_const::<'swap_path_1'>());
+    Order {
+        order_type: OrderType::StopLossDecrease,
+        account: contract_address_const::<'account'>(),
+        receiver: contract_address_const::<'receiver'>(),
+        callback_contract: contract_address_const::<'callback_contract'>(),
+        ui_fee_receiver: contract_address_const::<'ui_fee_receiver'>(),
+        market: contract_address_const::<'market'>(),
+        initial_collateral_token: contract_address_const::<'initial_collateral_token'>(),
+        swap_path,
+        size_delta_usd: 1000,
+        initial_collateral_delta_amount: 500,
+        trigger_price: 2000,
+        acceptable_price: 2500,
+        execution_fee: 100,
+        callback_gas_limit: 300000,
+        min_output_amount: 100,
+        updated_at_block: 0,
+        is_long: true,
+        should_unwrap_native_token: false,
+        is_frozen: false,
+    }
+}

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -222,6 +222,46 @@ fn test_emit_order_collateral_delta_amount_auto_updated() {
     assert(spy.events.len() == 0, 'There should be no events');
 }
 
+#[test]
+fn test_emit_order_cancelled() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (contract_address, event_emitter) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Create dummy data.
+    let key = 100;
+    let reason = 'none';
+    let reason_bytes = array!['0x00', '0x01'];
+
+    // Create the expected data.
+    let mut expected_data: Array<felt252> = array![key, reason.into()];
+    reason_bytes.serialize(ref expected_data);
+
+    // Emit the event.
+    event_emitter.emit_order_cancelled(key, reason, reason_bytes);
+
+    // Assert the event was emitted.
+    spy
+        .assert_emitted(
+            @array![
+                Event {
+                    from: contract_address,
+                    name: 'OrderCancelled',
+                    keys: array![],
+                    data: expected_data
+                }
+            ]
+        );
+    // Assert there are no more events.
+    assert(spy.events.len() == 0, 'There should be no events');
+}
+
 
 /// Utility function to setup the test environment.
 ///

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -85,6 +85,56 @@ fn test_emit_order_executed() {
     assert(spy.events.len() == 0, 'There should be no events');
 }
 
+#[test]
+fn test_emit_order_updated() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (contract_address, event_emitter) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Create dummy data.
+    let key = 100;
+    let size_delta_usd: u128 = 200;
+    let acceptable_price: u128 = 300;
+    let trigger_price: u128 = 400;
+    let min_output_amount: u128 = 500;
+
+    // Create the expected data.
+    let expected_data: Array<felt252> = array![
+        key,
+        size_delta_usd.into(),
+        acceptable_price.into(),
+        trigger_price.into(),
+        min_output_amount.into()
+    ];
+
+    // Emit the event.
+    event_emitter
+        .emit_order_updated(
+            key, size_delta_usd, acceptable_price, trigger_price, min_output_amount
+        );
+
+    // Assert the event was emitted.
+    spy
+        .assert_emitted(
+            @array![
+                Event {
+                    from: contract_address,
+                    name: 'OrderUpdated',
+                    keys: array![],
+                    data: expected_data
+                }
+            ]
+        );
+    // Assert there are no more events.
+    assert(spy.events.len() == 0, 'There should be no events');
+}
+
 
 /// Utility function to setup the test environment.
 ///

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -4,7 +4,7 @@ use snforge_std::{
     EventAssertions
 };
 
-use satoru::event::event_emitter::{IEventEmitterSafeDispatcher, IEventEmitterSafeDispatcherTrait};
+use satoru::event::event_emitter::{IEventEmitterDispatcher, IEventEmitterDispatcherTrait};
 use satoru::order::order::{Order, OrderType, SecondaryOrderType};
 
 //TODO: OrderCollatDeltaAmountAutoUpdtd must be renamed back to OrderCollateralDeltaAmountAutoUpdated when string will be allowed as event argument
@@ -305,11 +305,11 @@ fn test_emit_order_frozen() {
 /// # Returns
 ///
 /// * `ContractAddress` - The address of the event emitter contract.
-/// * `IEventEmitterSafeDispatcher` - The event emitter store dispatcher.
-fn setup() -> (ContractAddress, IEventEmitterSafeDispatcher) {
+/// * `IEventEmitterDispatcher` - The event emitter store dispatcher.
+fn setup() -> (ContractAddress, IEventEmitterDispatcher) {
     let contract = declare('EventEmitter');
     let contract_address = contract.deploy(@array![]).unwrap();
-    let event_emitter = IEventEmitterSafeDispatcher { contract_address };
+    let event_emitter = IEventEmitterDispatcher { contract_address };
     return (contract_address, event_emitter);
 }
 

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -5,7 +5,7 @@ use snforge_std::{
 };
 
 use satoru::event::event_emitter::{IEventEmitterSafeDispatcher, IEventEmitterSafeDispatcherTrait};
-use satoru::order::order::{Order, OrderType};
+use satoru::order::order::{Order, OrderType, SecondaryOrderType};
 
 #[test]
 fn test_emit_order_created() {
@@ -19,7 +19,7 @@ fn test_emit_order_created() {
     // *                              TEST LOGIC                                                   *
     // *********************************************************************************************
 
-    // Create a dummy data.
+    // Create dummy data.
     let key: felt252 = 100;
     let order: Order = create_dummy_order();
 
@@ -37,6 +37,45 @@ fn test_emit_order_created() {
                 Event {
                     from: contract_address,
                     name: 'OrderCreated',
+                    keys: array![],
+                    data: expected_data
+                }
+            ]
+        );
+    // Assert there are no more events.
+    assert(spy.events.len() == 0, 'There should be no events');
+}
+
+#[test]
+fn test_emit_order_executed() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (contract_address, event_emitter) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Create dummy data.
+    let key: felt252 = 100;
+    let secondary_order_type: SecondaryOrderType = SecondaryOrderType::None(());
+
+    // Create the expected data.
+    let mut expected_data: Array<felt252> = array![key];
+    secondary_order_type.serialize(ref expected_data);
+
+    // Emit the event.
+    event_emitter.emit_order_executed(key, secondary_order_type);
+
+    // Assert the event was emitted.
+    spy
+        .assert_emitted(
+            @array![
+                Event {
+                    from: contract_address,
+                    name: 'OrderExecuted',
                     keys: array![],
                     data: expected_data
                 }

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -7,6 +7,8 @@ use snforge_std::{
 use satoru::event::event_emitter::{IEventEmitterSafeDispatcher, IEventEmitterSafeDispatcherTrait};
 use satoru::order::order::{Order, OrderType, SecondaryOrderType};
 
+//TODO: OrderCollatDeltaAmountAutoUpdtd must be renamed back to OrderCollateralDeltaAmountAutoUpdated when string will be allowed as event argument
+
 #[test]
 fn test_emit_order_created() {
     // *********************************************************************************************
@@ -167,6 +169,50 @@ fn test_emit_order_size_delta_auto_updated() {
                 Event {
                     from: contract_address,
                     name: 'OrderSizeDeltaAutoUpdated',
+                    keys: array![],
+                    data: expected_data
+                }
+            ]
+        );
+    // Assert there are no more events.
+    assert(spy.events.len() == 0, 'There should be no events');
+}
+
+#[test]
+fn test_emit_order_collateral_delta_amount_auto_updated() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (contract_address, event_emitter) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Create dummy data.
+    let key = 100;
+    let collateral_delta_amount: u128 = 200;
+    let next_collateral_delta_amount: u128 = 300;
+
+    // Create the expected data.
+    let expected_data: Array<felt252> = array![
+        key, collateral_delta_amount.into(), next_collateral_delta_amount.into(),
+    ];
+
+    // Emit the event.
+    event_emitter
+        .emit_order_collateral_delta_amount_auto_updated(
+            key, collateral_delta_amount, next_collateral_delta_amount
+        );
+
+    // Assert the event was emitted.
+    spy
+        .assert_emitted(
+            @array![
+                Event {
+                    from: contract_address,
+                    name: 'OrderCollatDeltaAmountAutoUpdtd',
                     keys: array![],
                     data: expected_data
                 }

--- a/tests/event/test_order_events_emitted.cairo
+++ b/tests/event/test_order_events_emitted.cairo
@@ -135,6 +135,47 @@ fn test_emit_order_updated() {
     assert(spy.events.len() == 0, 'There should be no events');
 }
 
+#[test]
+fn test_emit_order_size_delta_auto_updated() {
+    // *********************************************************************************************
+    // *                              SETUP                                                        *
+    // *********************************************************************************************
+    let (contract_address, event_emitter) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+
+    // *********************************************************************************************
+    // *                              TEST LOGIC                                                   *
+    // *********************************************************************************************
+
+    // Create dummy data.
+    let key = 100;
+    let size_delta_usd: u128 = 200;
+    let next_size_delta_usd: u128 = 300;
+
+    // Create the expected data.
+    let expected_data: Array<felt252> = array![
+        key, size_delta_usd.into(), next_size_delta_usd.into(),
+    ];
+
+    // Emit the event.
+    event_emitter.emit_order_size_delta_auto_updated(key, size_delta_usd, next_size_delta_usd);
+
+    // Assert the event was emitted.
+    spy
+        .assert_emitted(
+            @array![
+                Event {
+                    from: contract_address,
+                    name: 'OrderSizeDeltaAutoUpdated',
+                    keys: array![],
+                    data: expected_data
+                }
+            ]
+        );
+    // Assert there are no more events.
+    assert(spy.events.len() == 0, 'There should be no events');
+}
+
 
 /// Utility function to setup the test environment.
 ///


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ]  Documentation content changes
- [x] Testing
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Add tests for order events emitted

Resolves: #321  

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?
No

## Other information
Used foundry [spy_event](https://foundry-rs.github.io/starknet-foundry/appendix/cheatcodes/spy_events.html). Took the liberty to create a specific test file for orders events (. Could be refact on a single file that contain all events emitted by the eventEmitter.

Note: Due to `error: The value does not fit within the range of type core::felt252.` on event name for foundry spy_event and the telegram discussion, it was agreed that `OrderCollateralDeltaAmountAutoUpdated` event will be renamed into `OrderCollatDeltaAmountAutoUpdtd` as a quick solution. 
This change must be revert when string will be allowed on starknet foundry side. 
TODO has been added on both (event_emitter and test files)
