### PR TITLE
feat: mock gas utils

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -134,6 +134,7 @@ mod utils {
     mod u128_mask;
     mod hash;
     mod store_arrays;
+    mod starknet_utils;
 }
 
 // `liquidation` function to help with liquidations.

--- a/src/utils/starknet_utils.cairo
+++ b/src/utils/starknet_utils.cairo
@@ -1,0 +1,38 @@
+// *************************************************************************
+//                                  IMPORTS
+// *************************************************************************
+// Core lib imports.
+use integer::Felt252TryIntoU128;
+use option::OptionTrait;
+use array::ArrayTrait;
+
+/// gasleft() mock implementation.
+/// Accepts Array<felt252> because we don't know how many parameters we need in future.
+/// In mock way, the first element of array returned as result of gasleft.
+#[inline(always)]
+fn sn_gasleft(params: Array<felt252>) -> u128 {
+    if (params.len() == 0) {
+        return 0_u128;
+    }
+
+    let value: felt252 = *params.at(0);
+
+    let result: u128 = value.try_into().unwrap();
+
+    result
+}
+
+/// tx.gasprice mock implementation.
+/// If its mock implementation, returns first element of parameter as result.
+#[inline(always)]
+fn sn_gasprice(params: Array<felt252>) -> u128 {
+    if (params.len() == 0) {
+        return 0_u128;
+    }
+
+    let value: felt252 = *params.at(0);
+
+    let result: u128 = value.try_into().unwrap();
+
+    result
+}

--- a/tests/utils/test_starknet_utils.cairo
+++ b/tests/utils/test_starknet_utils.cairo
@@ -1,0 +1,29 @@
+use traits::Into;
+
+use satoru::data::data_store::IDataStoreSafeDispatcherTrait;
+use satoru::utils::starknet_utils::{sn_gasleft, sn_gasprice};
+use satoru::tests_lib::{setup, teardown};
+
+#[test]
+fn test_gasleft() {
+    // No value provided, so returns 0
+    let default_value = sn_gasleft(array![]);
+    assert(default_value == 0_u128, 'default value wrong');
+
+    // Value provided then returns that value
+    let value_as_felt: felt252 = 55_u128.into();
+    let some_value = sn_gasleft(array![value_as_felt]);
+    assert(some_value == 55_u128, 'some value wrong');
+}
+
+#[test]
+fn test_gasprice() {
+    // No value provided, so returns 0
+    let default_value = sn_gasprice(array![]);
+    assert(default_value == 0_u128, 'default value wrong');
+
+    // Value provided then returns that value
+    let value_as_felt: felt252 = 35_u128.into();
+    let some_value = sn_gasprice(array![value_as_felt]);
+    assert(some_value == 35_u128, 'some value wrong');
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
https://github.com/keep-starknet-strange/satoru/issues/348

# Pull Request type

Added gasprice and gasleft mock methods, which return the value provided. These can be used implementing [GasUtils.sol](https://github.com/gmx-io/gmx-synthetics/blob/77a2ff39f1414a105e8589d622bdb09ac3dd97d8/contracts/gas/GasUtils.sol). 
For future starknet upgrades, we can simply modify these methods instead of all gas calls.

Please add the labels corresponding to the type of changes your PR introduces:


- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
