### PR TITLE
Feat: Integration with Pragma Oracle

### DIFF
--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -195,6 +195,26 @@ trait IDataStore<TContractState> {
     fn get_market_keys(self: @TContractState, start: usize, end: usize) -> Array<ContractAddress>;
 
     // *************************************************************************
+    //                      Oracle related functions.
+    // *************************************************************************
+    /// Sets the token ID for a given contract address.
+    /// This function checks if the caller has the `CONTROLLER` role
+    /// before updating the `tokens_ids` mapping.
+    /// # Arguments
+    /// * `self` - Mutable reference to the contract state.
+    /// * `token` - Contract address for which to set the ID.
+    /// * `id` - The ID to set.
+    fn set_token_id(ref self: TContractState, token: ContractAddress, id: felt252);
+
+    /// Retrieves the token ID associated with a given contract address.
+    /// # Arguments
+    /// * `self` - Reference to the contract state.
+    /// * `token` - Contract address for which to retrieve the ID.
+    /// # Returns
+    /// Returns the ID associated with the given token address.
+    fn get_token_id(self: @TContractState, token: ContractAddress) -> felt252;
+
+    // *************************************************************************
     //                      Order related functions.
     // *************************************************************************
     /// Get a order value for the given key.
@@ -471,6 +491,8 @@ mod DataStore {
         market_values: LegacyMap::<ContractAddress, Market>,
         markets: List<Market>,
         market_indexes: LegacyMap::<ContractAddress, usize>,
+        /// Oracle storage
+        tokens_ids: LegacyMap::<ContractAddress, felt252>,
         /// Order storage
         order_values: LegacyMap::<felt252, Order>,
         orders: List<Order>,
@@ -844,6 +866,18 @@ mod DataStore {
 
         fn get_market_salt_hash(self: @ContractState, salt: felt252) -> felt252 {
             poseidon_hash_span(array![MARKET, salt].span())
+        }
+
+        // *************************************************************************
+        //                      Oracle related functions.
+        // *************************************************************************
+        fn set_token_id(ref self: ContractState, token: ContractAddress, id: felt252) {
+            self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
+            self.tokens_ids.write(token, id);
+        }
+
+        fn get_token_id(self: @ContractState, token: ContractAddress) -> felt252 {
+            self.tokens_ids.read(token)
         }
 
         // *************************************************************************

--- a/src/oracle/price_feed.cairo
+++ b/src/oracle/price_feed.cairo
@@ -1,46 +1,53 @@
-/// Mock interface used for oracle::get_price_feed_price. 
-use serde::Serde;
+/// Data Types
+/// The value is the `pair_id` of the data
+/// For future option, pair_id and expiration timestamp
+///
+/// * `Spot` - Spot price
+/// * `Future` - Future price
+/// * `Option` - Option price
+#[derive(Drop, Copy, Serde)]
+enum DataType {
+    SpotEntry: felt252,
+    FutureEntry: (felt252, u64),
+    GenericEntry: felt252,
+}
+
+#[derive(Serde, Drop, Copy)]
+struct PragmaPricesResponse {
+    price: u128,
+    decimals: u32,
+    last_updated_timestamp: u64,
+    num_sources_aggregated: u32,
+    expiration_timestamp: Option<u64>,
+}
 
 #[starknet::interface]
 trait IPriceFeed<TContractState> {
-    fn latest_round_data(self: @TContractState) -> (u128, u128, u128, u64, u128);
+    fn get_data_median(self: @TContractState, data_type: DataType) -> PragmaPricesResponse;
 }
 
 
-impl TupleSize5Serde<
-    E0,
-    E1,
-    E2,
-    E3,
-    E4,
-    impl E0Serde: Serde<E0>,
-    impl E0Drop: Drop<E0>,
-    impl E1Serde: Serde<E1>,
-    impl E1Drop: Drop<E1>,
-    impl E2Serde: Serde<E2>,
-    impl E2Drop: Drop<E2>,
-    impl E3Serde: Serde<E3>,
-    impl E3Drop: Drop<E3>,
-    impl E4Serde: Serde<E4>,
-    impl E4Drop: Drop<E4>,
-> of Serde<(E0, E1, E2, E3, E4)> {
-    fn serialize(self: @(E0, E1, E2, E3, E4), ref output: Array<felt252>) {
-        let (e0, e1, e2, e3, e4) = self;
-        e0.serialize(ref output);
-        e1.serialize(ref output);
-        e2.serialize(ref output);
-        e3.serialize(ref output);
-        e4.serialize(ref output)
-    }
-    fn deserialize(ref serialized: Span<felt252>) -> Option<(E0, E1, E2, E3, E4)> {
-        Option::Some(
-            (
-                E0Serde::deserialize(ref serialized)?,
-                E1Serde::deserialize(ref serialized)?,
-                E2Serde::deserialize(ref serialized)?,
-                E3Serde::deserialize(ref serialized)?,
-                E4Serde::deserialize(ref serialized)?
-            )
-        )
+// NOTE: mock for testing.
+#[starknet::contract]
+mod PriceFeed {
+    use super::{DataType, PragmaPricesResponse};
+
+    #[storage]
+    struct Storage {}
+
+    #[construct]
+    fn constructor() {}
+
+    #[external(v0)]
+    impl PriceFeedImpl of super::IPriceFeed<ContractState> {
+        fn get_data_median(self: @ContractState, data_type: DataType) -> PragmaPricesResponse {
+            PragmaPricesResponse {
+                price: 1700,
+                decimals: 18,
+                last_updated_timestamp: 0,
+                num_sources_aggregated: 5,
+                expiration_timestamp: Option::None,
+            }
+        }
     }
 }

--- a/src/tests/exchange/test_liquidation_handler.cairo
+++ b/src/tests/exchange/test_liquidation_handler.cairo
@@ -82,10 +82,16 @@ fn deploy_liquidation_handler(
 }
 
 fn deploy_oracle(
-    role_store_address: ContractAddress, oracle_store_address: ContractAddress
+    role_store_address: ContractAddress,
+    oracle_store_address: ContractAddress,
+    pragma_address: ContractAddress
 ) -> ContractAddress {
     let contract = declare('Oracle');
-    contract.deploy(@array![role_store_address.into(), oracle_store_address.into()]).unwrap()
+    contract
+        .deploy(
+            @array![role_store_address.into(), oracle_store_address.into(), pragma_address.into()]
+        )
+        .unwrap()
 }
 
 fn deploy_swap_handler(role_store_address: ContractAddress) -> ContractAddress {
@@ -99,7 +105,7 @@ fn deploy_referral_storage() -> ContractAddress {
 }
 
 fn deploy_oracle_store(
-    role_store_address: ContractAddress, event_emitter_address: ContractAddress
+    role_store_address: ContractAddress, event_emitter_address: ContractAddress,
 ) -> ContractAddress {
     let contract = declare('OracleStore');
     contract.deploy(@array![role_store_address.into(), event_emitter_address.into()]).unwrap()
@@ -124,7 +130,9 @@ fn _setup() -> (
     let order_vault_address = deploy_order_vault(data_store_address, role_store_address);
     let swap_handler_address = deploy_swap_handler(role_store_address);
     let oracle_store_address = deploy_oracle_store(role_store_address, event_emitter_address);
-    let oracle_address = deploy_oracle(role_store_address, oracle_store_address);
+    let oracle_address = deploy_oracle(
+        role_store_address, oracle_store_address, contract_address_const::<'pragma'>()
+    );
     //let referral_storage_address = deploy_referral_storage();
     let liquidation_handler_address = deploy_liquidation_handler(
         role_store_address,

--- a/src/tests/exchange/test_withdrawal_handler.cairo
+++ b/src/tests/exchange/test_withdrawal_handler.cairo
@@ -241,10 +241,14 @@ fn deploy_withdrawal_handler(
 }
 
 fn deploy_oracle(
-    oracle_store_address: ContractAddress, role_store_address: ContractAddress
+    oracle_store_address: ContractAddress,
+    role_store_address: ContractAddress,
+    pragma_address: ContractAddress
 ) -> ContractAddress {
     let contract = declare('Oracle');
-    let constructor_calldata = array![role_store_address.into(), oracle_store_address.into()];
+    let constructor_calldata = array![
+        role_store_address.into(), oracle_store_address.into(), pragma_address.into()
+    ];
     contract.deploy(@constructor_calldata).unwrap()
 }
 
@@ -300,7 +304,9 @@ fn setup() -> (
     let strict_bank_address = deploy_strict_bank(data_store_address, role_store_address);
     let withdrawal_vault_address = deploy_withdrawal_vault(strict_bank_address);
     let oracle_store_address = deploy_oracle_store(role_store_address, event_emitter_address);
-    let oracle_address = deploy_oracle(oracle_store_address, role_store_address);
+    let oracle_address = deploy_oracle(
+        oracle_store_address, role_store_address, contract_address_const::<'pragma'>()
+    );
     let withdrawal_handler_address = deploy_withdrawal_handler(
         data_store_address,
         role_store_address,

--- a/src/tests/swap/test_swap_handler.cairo
+++ b/src/tests/swap/test_swap_handler.cairo
@@ -30,12 +30,15 @@ fn deploy_event_emitter() -> ContractAddress {
 
 /// Utility function to deploy a `Oracle` contract and return its dispatcher.
 fn deploy_oracle(
-    role_store_address: ContractAddress, oracle_address: ContractAddress
+    role_store_address: ContractAddress,
+    oracle_address: ContractAddress,
+    pragma_address: ContractAddress
 ) -> ContractAddress {
     let contract = declare('Oracle');
     let mut constructor_calldata = array![];
     constructor_calldata.append(role_store_address.into());
     constructor_calldata.append(oracle_address.into());
+    constructor_calldata.append(pragma_address.into());
     contract.deploy(@constructor_calldata).unwrap()
 }
 
@@ -96,7 +99,11 @@ fn setup() -> (
     let event_emitter_address = deploy_event_emitter();
     let event_emitter = IEventEmitterDispatcher { contract_address: event_emitter_address };
 
-    let oracle_address = deploy_oracle(role_store_address, contract_address_const::<'oracle'>());
+    let oracle_address = deploy_oracle(
+        role_store_address,
+        contract_address_const::<'oracle'>(),
+        contract_address_const::<'pragma'>()
+    );
     let oracle = IOracleDispatcher { contract_address: oracle_address };
 
     let bank_address = deploy_bank_address(data_store_address, role_store_address);

--- a/src/tests_lib.cairo
+++ b/src/tests_lib.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress, Felt252TryIntoContractAddress};
+use starknet::{ContractAddress, Felt252TryIntoContractAddress, contract_address_const};
 use snforge_std::{declare, start_prank, stop_prank, ContractClassTrait};
 
 use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
@@ -49,10 +49,14 @@ fn deploy_oracle_store(
 
 /// Utility function to deploy a `EventEmitter` contract and return its dispatcher.
 fn deploy_oracle(
-    role_store_address: ContractAddress, oracle_store_address: ContractAddress
+    role_store_address: ContractAddress,
+    oracle_store_address: ContractAddress,
+    pragma_address: ContractAddress
 ) -> ContractAddress {
     let contract = declare('Oracle');
-    let constructor_calldata = array![role_store_address.into(), oracle_store_address.into()];
+    let constructor_calldata = array![
+        role_store_address.into(), oracle_store_address.into(), pragma_address.into()
+    ];
     contract.deploy(@constructor_calldata).unwrap()
 }
 
@@ -115,7 +119,9 @@ fn setup_oracle_and_store() -> (
     start_prank(data_store_address, caller_address);
     let (event_emitter_address, event_emitter) = setup_event_emitter();
     let oracle_store_address = deploy_oracle_store(role_store_address, event_emitter_address);
-    let oracle_address = deploy_oracle(role_store_address, oracle_store_address);
+    let oracle_address = deploy_oracle(
+        role_store_address, oracle_store_address, contract_address_const::<'pragma'>()
+    );
     let oracle = IOracleDispatcher { contract_address: oracle_address };
     (caller_address, role_store, data_store, event_emitter, oracle)
 }


### PR DESCRIPTION
### PR Type
- [x] Enhancement

### Changes Introduced
The `Oracle` contract now supports Pragma oracle integration. Added a new `pragma_address` constructor argument and `price_feed` storage variable for the updated `IPriceFeed` dispatcher.

To make this possible, `DataStore` has been extended with two new methods: `set_token_id` and `get_token_id`. A new storage map `tokens_ids: LegacyMap::<ContractAddress, felt252>` is also introduced.

Test suite has been updated accordingly.