### PR TITLE
Feat/i128 operations (div, mul, storage, serde)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "sarif-viewer.connectToGithubCodeScanning": "off"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "sarif-viewer.connectToGithubCodeScanning": "off"
-}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -319,6 +319,7 @@ mod tests {
         mod test_reentrancy_guard;
         mod test_starknet_utils;
         mod test_u128_mask;
+        mod test_i128;
     }
 }
 
@@ -330,4 +331,92 @@ mod withdrawal {
     mod withdrawal_utils;
     mod withdrawal_vault;
     mod withdrawal;
+}
+
+// TODO Remove this once implemented by Starkware
+impl I128Div of Div<i128> {
+    fn div(lhs: i128, rhs: i128) -> i128 {
+        assert(rhs != 0, 'Division by 0');
+        let u_lhs = abs(lhs);
+        let u_rhs = abs(rhs);
+        let response = u_lhs / u_rhs;
+        let response: felt252 = response.into();
+        if (lhs > 0 && rhs > 0) || (lhs < 0 && rhs < 0) {
+            response.try_into().expect('i128 Overflow')
+        } else {
+            -response.try_into().expect('i128 Overflow')
+        }
+    }
+}
+
+impl I1288Mul of Mul<i128> {
+    fn mul(lhs: i128, rhs: i128) -> i128 {
+        let u_lhs = abs(lhs);
+        let u_rhs = abs(rhs);
+        let response = u_lhs * u_rhs;
+        let response: felt252 = response.into();
+        if (lhs > 0 && rhs > 0) || (lhs < 0 && rhs < 0) {
+            response.try_into().expect('i128 Overflow')
+        } else {
+            -response.try_into().expect('i128 Overflow')
+        }
+    }
+}
+
+fn abs(signed_integer: i128) -> u128 {
+    let response = if signed_integer < 0 {
+        -signed_integer
+    } else {
+        signed_integer
+    };
+    let response: felt252 = response.into();
+    response.try_into().expect('u128 Overflow')
+}
+
+use starknet::{
+    storage_access::{Store, StorageBaseAddress},
+    {SyscallResult, syscalls::{storage_read_syscall, storage_write_syscall}}
+};
+
+impl StoreI128 of Store<i128> {
+    fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<i128> {
+        Result::Ok(
+            Store::<felt252>::read(address_domain, base)?.try_into().expect('StoreI128 - non i128')
+        )
+    }
+    #[inline(always)]
+    fn write(address_domain: u32, base: StorageBaseAddress, value: i128) -> SyscallResult<()> {
+        Store::<felt252>::write(address_domain, base, value.into())
+    }
+    #[inline(always)]
+    fn read_at_offset(
+        address_domain: u32, base: StorageBaseAddress, offset: u8
+    ) -> SyscallResult<i128> {
+        Result::Ok(
+            Store::<felt252>::read_at_offset(address_domain, base, offset)?
+                .try_into()
+                .expect('StoreI128 - non i128')
+        )
+    }
+    #[inline(always)]
+    fn write_at_offset(
+        address_domain: u32, base: StorageBaseAddress, offset: u8, value: i128
+    ) -> SyscallResult<()> {
+        Store::<felt252>::write_at_offset(address_domain, base, offset, value.into())
+    }
+    #[inline(always)]
+    fn size() -> u8 {
+        1_u8
+    }
+}
+
+impl I128Serde of Serde<i128> {
+    fn serialize(self: @i128, ref output: Array<felt252>) {
+        output.append((*self).into());
+    }
+    fn deserialize(ref serialized: Span<felt252>) -> Option<i128> {
+        let felt_val = *(serialized.pop_front().expect('i128 deserialize'));
+        let i128_val = felt_val.try_into().expect('i128 Overflow');
+        Option::Some(i128_val)
+    }
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -333,7 +333,12 @@ mod withdrawal {
     mod withdrawal;
 }
 
-// TODO Remove this once implemented by Starkware
+// TODO Remove all below once natif
+use starknet::{
+    storage_access::{Store, StorageBaseAddress},
+    {SyscallResult, syscalls::{storage_read_syscall, storage_write_syscall}}
+};
+
 impl I128Div of Div<i128> {
     fn div(lhs: i128, rhs: i128) -> i128 {
         assert(rhs != 0, 'Division by 0');
@@ -372,11 +377,6 @@ fn abs(signed_integer: i128) -> u128 {
     let response: felt252 = response.into();
     response.try_into().expect('u128 Overflow')
 }
-
-use starknet::{
-    storage_access::{Store, StorageBaseAddress},
-    {SyscallResult, syscalls::{storage_read_syscall, storage_write_syscall}}
-};
 
 impl StoreI128 of Store<i128> {
     fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<i128> {

--- a/src/order/base_order_utils.cairo
+++ b/src/order/base_order_utils.cairo
@@ -6,6 +6,7 @@ use integer::BoundedInt;
 use starknet::ContractAddress;
 
 // Local imports.
+use satoru::I128Div;
 use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
 use satoru::event::event_emitter::{IEventEmitterDispatcher, IEventEmitterDispatcherTrait};
 use satoru::oracle::oracle::{IOracleDispatcher, IOracleDispatcherTrait};
@@ -434,7 +435,7 @@ fn get_execution_price_for_decrease(
         let numerator = precision::mul_div_inum(
             position_size_in_usd, adjusted_price_impact_usd, position_size_in_tokens
         );
-        let adjustment = div_i128(numerator, u128_to_i128(size_delta_usd));
+        let adjustment = numerator / u128_to_i128(size_delta_usd);
 
         let _execution_price: i128 = u128_to_i128(price) + adjustment;
 
@@ -537,18 +538,4 @@ fn i128_to_u128(value: i128) -> u128 {
     assert(value >= 0, 'i128_to_u128: value is negative');
     let value: felt252 = value.into();
     value.try_into().unwrap()
-}
-
-// TODO: remove this when i128 division available
-#[inline(always)]
-fn div_i128(numerator: i128, denominator: i128) -> i128 {
-    if numerator < 0 && denominator < 0 {
-        u128_to_i128(i128_to_u128(numerator) / i128_to_u128(denominator))
-    } else if numerator < 0 {
-        -u128_to_i128(i128_to_u128(-numerator) / i128_to_u128(denominator))
-    } else if denominator < 0 {
-        -u128_to_i128(i128_to_u128(numerator) / i128_to_u128(-denominator))
-    } else {
-        u128_to_i128(i128_to_u128(numerator) / i128_to_u128(denominator))
-    }
 }

--- a/src/tests/utils/test_i128.cairo
+++ b/src/tests/utils/test_i128.cairo
@@ -1,0 +1,114 @@
+use satoru::{I128Div, I1288Mul, I128Serde};
+use snforge_std::{declare, ContractClassTrait};
+
+
+// Div
+#[test]
+fn test_i128_division() {
+    assert(12_i128 / 3 == 4, 'should be 4');
+}
+
+#[test]
+fn test_i128_division_lhs_neg() {
+    assert(-12_i128 / 3 == -4, 'should be -4');
+}
+
+#[test]
+fn test_i128_division_rhs_neg() {
+    assert(12_i128 / -3 == -4, 'should be -4');
+}
+
+#[test]
+fn test_i128_division_both_neg() {
+    assert(-12_i128 / -3 == 4, 'should be 4');
+}
+
+#[test]
+fn test_i128_division_zero() {
+    assert(0_i128 / -3 == 0, 'should be 0');
+}
+
+#[test]
+#[should_panic(expected: ('Division by 0',))]
+fn test_i128_division_by_zero() {
+    -12_i128 / 0;
+}
+
+// Mul 
+#[test]
+fn test_i128_multiplication() {
+    assert(12_i128 * 3 == 36, 'should be 36');
+}
+
+#[test]
+fn test_i128_multiplication_lhs_neg() {
+    assert(-12_i128 * 3 == -36, 'should be -36');
+}
+
+#[test]
+fn test_i128_multiplication_rhs_neg() {
+    assert(12_i128 * -3 == -36, 'should be -36');
+}
+
+#[test]
+fn test_i128_multiplication_both_neg() {
+    assert(-12_i128 * -3 == 36, 'should be 36');
+}
+
+#[test]
+fn test_i128_multiplication_zero() {
+    assert(0_i128 * -3 == 0, 'should be 0');
+}
+
+#[test]
+fn test_i128_multiplication_by_zero() {
+    assert(-3_i128 * 0 == 0, 'should be 0');
+}
+
+#[starknet::interface]
+trait ITestI128Storage<TContractState> {
+    fn set_i128(ref self: TContractState, new_val: i128);
+    fn get_i128(self: @TContractState) -> i128;
+}
+
+#[starknet::contract]
+mod test_i128_storage_contract {
+    use satoru::{StoreI128, I128Serde};
+    use super::ITestI128Storage;
+
+
+    #[storage]
+    struct Storage {
+        my_i128: i128
+    }
+
+    #[external(v0)]
+    impl Public of ITestI128Storage<ContractState> {
+        fn set_i128(ref self: ContractState, new_val: i128) {
+            self.my_i128.write(new_val);
+        }
+        fn get_i128(self: @ContractState) -> i128 {
+            self.my_i128.read()
+        }
+    }
+}
+
+use starknet::{deploy_syscall, ClassHash};
+
+fn deploy() -> ITestI128StorageDispatcher {
+    let contract = declare('test_i128_storage_contract');
+    let contract_address = contract.deploy(@array![]).unwrap();
+    ITestI128StorageDispatcher { contract_address }
+}
+
+#[test]
+fn test_i128_storage() {
+    let dispatcher = deploy();
+    assert(dispatcher.get_i128() == 0, 'should be 0');
+    dispatcher.set_i128(12);
+    assert(dispatcher.get_i128() == 12, 'should be 12');
+    dispatcher.set_i128(-42);
+    assert(dispatcher.get_i128() == -42, 'should be -42');
+    dispatcher.set_i128(0);
+    assert(dispatcher.get_i128() == 0, 'should be back to 0');
+}


### PR DESCRIPTION
# Pull Request type

Adding missing operations on i128:
 - div
 - mul
 - storage (and thus serde)

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

Resolves: #406 

## What is the new behavior?

Should now be possible to divide, multiply and store i128
 
## Does this introduce a breaking change?

No

## Other information

It probably isn't the most efficient way, but this **SHOULD** be deleted once we upgrade the Cairo compiler version to a version that supports operations on i128 (prob 2.3.0)