### PR TITLE
Feat:Implement deposit_utils

### DIFF
--- a/src/bank/strict_bank.cairo
+++ b/src/bank/strict_bank.cairo
@@ -31,6 +31,7 @@ trait IStrictBank<TContractState> {
     fn transfer_out(
         ref self: TContractState, token: ContractAddress, receiver: ContractAddress, amount: u128,
     );
+
     /// Updates the `token_balances` in case of token burns or similar balance changes.
     /// The `prev_balance` is not validated to be more than the `next_balance` as this
     /// could allow someone to block this call by transferring into the contract.

--- a/src/deposit/deposit.cairo
+++ b/src/deposit/deposit.cairo
@@ -35,7 +35,7 @@ struct Deposit {
     /// The minimum acceptable number of liquidity tokens.
     min_market_tokens: u128,
     /// The block that the deposit was last updated at sending funds back to the user in case the deposit gets cancelled.
-    updated_at_block: u128,
+    updated_at_block: u64,
     /// The execution fee for keepers.
     execution_fee: u128,
     /// The gas limit for the callback contract.

--- a/src/deposit/deposit_utils.cairo
+++ b/src/deposit/deposit_utils.cairo
@@ -8,13 +8,23 @@
 use starknet::ContractAddress;
 use result::ResultTrait;
 
-use debug::PrintTrait;
 // Local imports.
-use satoru::utils::store_arrays::StoreContractAddressArray;
+use satoru::utils::{
+    starknet_utils, store_arrays::StoreContractAddressArray, account_utils::validate_account,
+    account_utils::validate_receiver, span32::Span32
+};
 use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
 use satoru::event::event_emitter::{IEventEmitterDispatcher, IEventEmitterDispatcherTrait};
 use satoru::deposit::deposit_vault::{IDepositVaultDispatcher, IDepositVaultDispatcherTrait};
-use satoru::utils::span32::Span32;
+use satoru::chain::chain::{IChainDispatcher, IChainDispatcherTrait};
+use satoru::deposit::{deposit::Deposit, error::DepositError};
+use satoru::market::market_utils;
+use satoru::gas::{error::GasError, gas_utils};
+use satoru::callback::callback_utils::{validate_callback_gas_limit, after_deposit_cancellation};
+use satoru::nonce::nonce_utils;
+use satoru::token::token_utils;
+use starknet::contract_address::ContractAddressZeroable;
+use satoru::event::event_utils::EventLogData;
 
 /// Helps with deposit creation.
 #[derive(Drop, starknet::Store, Serde)]
@@ -41,7 +51,7 @@ struct CreateDepositParams {
     /// to the user in case the deposit gets cancelled.
     should_unwrap_native_token: bool,
     /// The execution fee for keepers.
-    execution_fee: u256,
+    execution_fee: u128,
     /// The gas limit for the callback_contract.
     callback_gas_limit: u128,
 }
@@ -58,11 +68,74 @@ fn create_deposit(
     data_store: IDataStoreDispatcher,
     event_emitter: IEventEmitterDispatcher,
     deposit_vault: IDepositVaultDispatcher,
+    chain: IChainDispatcher,
     account: ContractAddress,
-    params: CreateDepositParams
+    mut params: CreateDepositParams
 ) -> felt252 {
-    //TODO
-    0
+    validate_account(account);
+
+    let market = data_store.get_market(params.market);
+    market_utils::validate_swap_path(data_store, params.long_token_swap_path);
+    market_utils::validate_swap_path(data_store, params.short_token_swap_path);
+
+    // if the initialLongToken and initialShortToken are the same, only the initialLongTokenAmount would
+    // be non-zero, the initialShortTokenAmount would be zero
+    let mut initial_long_token_amount = deposit_vault.record_transfer_in(params.initial_long_token);
+    let mut initial_short_token_amount = deposit_vault
+        .record_transfer_in(params.initial_short_token);
+
+    let wnt: ContractAddress = token_utils::wnt(data_store);
+
+    if params.initial_long_token == wnt {
+        initial_long_token_amount -= params.execution_fee;
+    } else if params.initial_short_token == wnt {
+        initial_short_token_amount -= params.execution_fee;
+    } else {
+        let wnt_amount = deposit_vault.record_transfer_in(wnt);
+        assert(
+            wnt_amount > params.execution_fee, GasError::INSUFFICIENT_WNT_AMOUNT_FOR_EXECUTION_FEE
+        );
+
+        params.execution_fee = wnt_amount;
+    }
+
+    assert(
+        initial_long_token_amount > 0 && initial_short_token_amount > 0,
+        DepositError::EMPTY_DEPOSIT_AMOUNTS
+    );
+
+    validate_receiver(params.receiver);
+    let key = nonce_utils::get_next_key(data_store);
+    let deposit = Deposit {
+        key,
+        account: account,
+        receiver: params.receiver,
+        callback_contract: params.callback_contract,
+        ui_fee_receiver: params.ui_fee_receiver,
+        market: params.market,
+        initial_long_token: params.initial_long_token,
+        initial_short_token: params.initial_short_token,
+        long_token_swap_path: params.long_token_swap_path,
+        short_token_swap_path: params.short_token_swap_path,
+        initial_long_token_amount: initial_long_token_amount,
+        initial_short_token_amount: initial_short_token_amount,
+        min_market_tokens: params.min_market_tokens,
+        // TODO : use chain.get_block_number chain will be a library
+        updated_at_block: chain.get_block_number(),
+        execution_fee: params.execution_fee,
+        callback_gas_limit: params.callback_gas_limit,
+    };
+
+    validate_callback_gas_limit(data_store, deposit.callback_gas_limit);
+    let estimated_gas_limit = gas_utils::estimate_execute_deposit_gas_limit(data_store, deposit);
+    gas_utils::validate_execution_fee(data_store, estimated_gas_limit, params.execution_fee);
+
+    // add deposit values in data_store 
+    data_store.set_deposit(key, deposit);
+
+    // emit event
+    event_emitter.emit_deposit_created(key, deposit);
+    key
 }
 
 /// Cancels a deposit, funds are sent back to the user.
@@ -79,9 +152,56 @@ fn cancel_deposit(
     event_emitter: IEventEmitterDispatcher,
     deposit_vault: IDepositVaultDispatcher,
     key: felt252,
-    address: ContractAddress,
-    starting_gas: u128,
+    keeper: ContractAddress,
+    mut starting_gas: u128,
     reason: felt252,
     reason_bytes: Array<felt252>
-) { //TODO
+) {
+    starting_gas -= (starknet_utils::sn_gasleft(array![]) / 63);
+
+    // get deposit info from data_store
+    let mut deposit = Default::default();
+    match data_store.get_deposit(key) {
+        Option::Some(stored_deposit) => deposit = stored_deposit,
+        Option::None => panic(array![DepositError::EMPTY_DEPOSIT, key])
+    }
+
+    assert(ContractAddressZeroable::is_non_zero(deposit.account), DepositError::EMPTY_DEPOSIT);
+    assert(
+        deposit.initial_long_token_amount > 0 && deposit.initial_short_token_amount > 0,
+        DepositError::EMPTY_DEPOSIT_AMOUNTS
+    );
+
+    // remove key,account from data_store
+    data_store.remove_deposit(key, deposit.account);
+
+    if deposit.initial_long_token_amount > 0 {
+        deposit_vault
+            .transfer_out(
+                deposit.initial_long_token, deposit.account, deposit.initial_long_token_amount
+            );
+    }
+
+    if deposit.initial_short_token_amount > 0 {
+        deposit_vault
+            .transfer_out(
+                deposit.initial_short_token, deposit.account, deposit.initial_short_token_amount
+            );
+    }
+
+    event_emitter.emit_deposit_cancelled(key, reason, reason_bytes.span());
+
+    let event_log_data = EventLogData { cant_be_empty: 0 };
+    after_deposit_cancellation(key, deposit, event_log_data, event_emitter);
+
+    gas_utils::pay_execution_fee_deposit(
+        data_store,
+        event_emitter,
+        deposit_vault,
+        deposit.execution_fee,
+        starting_gas,
+        keeper,
+        deposit.account
+    );
 }
+

--- a/src/deposit/deposit_vault.cairo
+++ b/src/deposit/deposit_vault.cairo
@@ -12,7 +12,33 @@ use starknet::ContractAddress;
 //                  Interface of the `DepositVault` contract.
 // *************************************************************************
 #[starknet::interface]
-trait IDepositVault<TContractState> {}
+trait IDepositVault<TContractState> {
+    /// Initialize the contract.
+    /// # Arguments
+    /// * `data_store_address` - The address of the data store contract.
+    /// * `role_store_address` - The address of the role store contract.
+    fn initialize(
+        ref self: TContractState,
+        data_store_address: ContractAddress,
+        role_store_address: ContractAddress,
+    );
+
+    /// Transfer tokens from this contract to a receiver.
+    /// # Arguments
+    /// * `token` - The token address to transfer.
+    /// * `receiver` - The address of the receiver.
+    /// * `amount` - The amount of tokens to transfer.
+    fn transfer_out(
+        ref self: TContractState, token: ContractAddress, receiver: ContractAddress, amount: u128,
+    );
+
+    /// Records a token transfer into the contract.
+    /// # Arguments
+    /// * `token` - The token address to transfer.
+    /// # Returns
+    /// * The amount of tokens transferred.
+    fn record_transfer_in(ref self: TContractState, token: ContractAddress) -> u128;
+}
 
 #[starknet::contract]
 mod DepositVault {
@@ -29,6 +55,8 @@ mod DepositVault {
     // Local imports.
     use satoru::role::role_store::{IRoleStoreDispatcher, IRoleStoreDispatcherTrait};
     use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
+    use satoru::bank::strict_bank::{StrictBank, IStrictBank};
+
 
     // *************************************************************************
     //                              STORAGE
@@ -64,5 +92,30 @@ mod DepositVault {
     //                          EXTERNAL FUNCTIONS
     // *************************************************************************
     #[external(v0)]
-    impl DepositVaultImpl of super::IDepositVault<ContractState> {}
+    impl DepositVaultImpl of super::IDepositVault<ContractState> {
+        fn initialize(
+            ref self: ContractState,
+            data_store_address: ContractAddress,
+            role_store_address: ContractAddress,
+        ) {
+            let mut state: StrictBank::ContractState = StrictBank::unsafe_new_contract_state();
+            IStrictBank::initialize(ref state, data_store_address, role_store_address);
+        }
+
+
+        fn transfer_out(
+            ref self: ContractState,
+            token: ContractAddress,
+            receiver: ContractAddress,
+            amount: u128,
+        ) {
+            let mut state: StrictBank::ContractState = StrictBank::unsafe_new_contract_state();
+            IStrictBank::transfer_out(ref state, token, receiver, amount);
+        }
+
+        fn record_transfer_in(ref self: ContractState, token: ContractAddress) -> u128 {
+            // TODO
+            0
+        }
+    }
 }

--- a/src/deposit/error.cairo
+++ b/src/deposit/error.cairo
@@ -2,4 +2,6 @@ mod DepositError {
     const DEPOSIT_NOT_FOUND: felt252 = 'deposit_not_found';
     const DEPOSIT_INDEX_NOT_FOUND: felt252 = 'deposit_index_not_found';
     const CANT_BE_ZERO: felt252 = 'deposit account cant be 0';
+    const EMPTY_DEPOSIT_AMOUNTS: felt252 = 'empty_deposit_amounts';
+    const EMPTY_DEPOSIT: felt252 = 'empty_deposit';
 }

--- a/src/event/event_emitter.cairo
+++ b/src/event/event_emitter.cairo
@@ -839,7 +839,7 @@ mod EventEmitter {
         initial_long_token_amount: u128,
         initial_short_token_amount: u128,
         min_market_tokens: u128,
-        updated_at_block: u128,
+        updated_at_block: u64,
         execution_fee: u128,
         callback_gas_limit: u128,
     }
@@ -870,7 +870,7 @@ mod EventEmitter {
         min_long_token_amount: u128,
         min_short_token_amount: u128,
         updated_at_block: u64,
-        execution_fee: u256,
+        execution_fee: u128,
         callback_gas_limit: u128,
         should_unwrap_native_token: bool
     }

--- a/src/gas/error.cairo
+++ b/src/gas/error.cairo
@@ -1,0 +1,3 @@
+mod GasError {
+    const INSUFFICIENT_WNT_AMOUNT_FOR_EXECUTION_FEE: felt252 = 'insffcient_wnt_amt_for_exec_fee';
+}

--- a/src/gas/gas_utils.cairo
+++ b/src/gas/gas_utils.cairo
@@ -14,6 +14,7 @@ use satoru::withdrawal::{
     withdrawal::Withdrawal,
     withdrawal_vault::{IWithdrawalVaultDispatcher, IWithdrawalVaultDispatcherTrait}
 };
+use satoru::deposit::deposit_vault::{IDepositVaultDispatcher, IDepositVaultDispatcherTrait};
 
 /// Get the minimal gas to handle execution.
 /// # Arguments
@@ -47,7 +48,29 @@ fn pay_execution_fee(
     data_store: IDataStoreDispatcher,
     event_emitter: IEventEmitterDispatcher,
     bank: IWithdrawalVaultDispatcher,
-    execution_fee: u256,
+    execution_fee: u128,
+    starting_gas: u128,
+    keeper: ContractAddress,
+    refund_receiver: ContractAddress
+) { // TODO
+}
+
+/// Pay the keeper the execution fee and refund any excess amount.
+/// # Arguments
+/// * `data_store` - The data storage contract dispatcher.
+/// * `event_emitter` - The event emitter contract dispatcher.
+/// * `bank` - The StrictBank contract holding the execution fee.
+/// * `execution_fee` - The executionFee amount.
+/// * `starting_gas` - The starting gas.
+/// * `keeper` - The keeper to pay.
+/// * `refund_receiver` - The account that should receive any excess gas refunds.
+/// # Returns
+/// * The key for the account order list.
+fn pay_execution_fee_deposit(
+    data_store: IDataStoreDispatcher,
+    event_emitter: IEventEmitterDispatcher,
+    bank: IDepositVaultDispatcher,
+    execution_fee: u128,
     starting_gas: u128,
     keeper: ContractAddress,
     refund_receiver: ContractAddress
@@ -62,7 +85,7 @@ fn pay_execution_fee(
 /// # Returns
 /// * The key for the account order list.
 fn validate_execution_fee(
-    data_store: IDataStoreDispatcher, estimated_gas_limit: u128, execution_fee: u256
+    data_store: IDataStoreDispatcher, estimated_gas_limit: u128, execution_fee: u128
 ) { // TODO
 }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -91,6 +91,7 @@ mod fee {
 // `gas` is used for execution fee estimation and payments.
 mod gas {
     mod gas_utils;
+    mod error;
 }
 
 // `nonce` is a module that maintains a progressively increasing nonce value.

--- a/src/order/order.cairo
+++ b/src/order/order.cairo
@@ -47,7 +47,7 @@ struct Order {
     /// The acceptable execution price for increase / decrease orders.
     acceptable_price: u128,
     /// The execution fee for keepers.
-    execution_fee: u256,
+    execution_fee: u128,
     /// The gas limit for the callbackContract.
     callback_gas_limit: u128,
     /// The minimum output amount for decrease orders and swaps.

--- a/src/order/order_vault.cairo
+++ b/src/order/order_vault.cairo
@@ -27,7 +27,7 @@ trait IOrderVault<TContractState> {
     /// * `token` - The token address to transfer.
     /// # Returns
     /// * The amount of tokens transferred.
-    fn record_transfer_in(ref self: TContractState, token: ContractAddress) -> u256;
+    fn record_transfer_in(ref self: TContractState, token: ContractAddress) -> u128;
 }
 
 #[starknet::contract]
@@ -80,7 +80,7 @@ mod OrderVault {
         ) { // TODO
         }
 
-        fn record_transfer_in(ref self: ContractState, token: ContractAddress) -> u256 {
+        fn record_transfer_in(ref self: ContractState, token: ContractAddress) -> u128 {
             // TODO
             0
         }

--- a/src/tests/data/test_order.cairo
+++ b/src/tests/data/test_order.cairo
@@ -444,7 +444,7 @@ fn create_new_order(
     let initial_collateral_delta_amount = 1000 * order_no;
     let trigger_price = 11111 * order_no;
     let acceptable_price = 11111 * order_no;
-    let execution_fee: u256 = 10 * order_no.into();
+    let execution_fee: u128 = 10 * order_no.into();
     let min_output_amount = 10 * order_no;
     let updated_at_block = 1;
 

--- a/src/tests/deposit/test_deposit_utils.cairo
+++ b/src/tests/deposit/test_deposit_utils.cairo
@@ -50,7 +50,6 @@ fn should_panic_if_unsufficient_wnt_amount_for_deposit() {
 //     );
 // }
 
-
 #[test]
 fn should_cancel_deposit() {
     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();

--- a/src/tests/deposit/test_deposit_utils.cairo
+++ b/src/tests/deposit/test_deposit_utils.cairo
@@ -18,7 +18,7 @@ use snforge_std::{declare, start_prank, ContractClassTrait};
 
 
 #[test]
-fn should_create_deposit() {
+fn given_normal_conditions_when_deposit_then_works() {
     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
     let account: ContractAddress = 'account'.try_into().unwrap();
     let deposit_param = create_dummy_deposit_param();
@@ -30,7 +30,7 @@ fn should_create_deposit() {
 
 #[test]
 #[should_panic(expected: ('insffcient_wnt_amt_for_exec_fee',))]
-fn should_panic_if_unsufficient_wnt_amount_for_deposit() {
+fn given_unsufficient_wnt_amount_for_deposit_then_fails() {
     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
     let account: ContractAddress = 'account'.try_into().unwrap();
     let deposit_param = create_dummy_deposit_param();
@@ -41,7 +41,7 @@ fn should_panic_if_unsufficient_wnt_amount_for_deposit() {
 
 // #[test]
 // #[should_panic(expected: ('empty_deposit_amounts',))]
-// fn should_panic_on_empty_deposit_amount() {
+// fn given_empty_deposit_amount_then_fails() {
 //     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
 //     let account: ContractAddress = 'account'.try_into().unwrap();
 //     let deposit_param = create_dummy_deposit_param();
@@ -51,7 +51,7 @@ fn should_panic_if_unsufficient_wnt_amount_for_deposit() {
 // }
 
 #[test]
-fn should_cancel_deposit() {
+fn given_normal_conditions_when_cancel_deposit_then_works() {
     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
     let account: ContractAddress = 'account'.try_into().unwrap();
     let keeper: ContractAddress = 'keeper'.try_into().unwrap();

--- a/src/tests/deposit/test_deposit_utils.cairo
+++ b/src/tests/deposit/test_deposit_utils.cairo
@@ -23,7 +23,7 @@ fn given_normal_conditions_when_deposit_then_works() {
     let account: ContractAddress = 'account'.try_into().unwrap();
     let deposit_param = create_dummy_deposit_param();
 // let key = create_deposit(
-//     data_store, event_emitter, deposit_vault, chain, account, deposit_param
+//     data_store, event_emitter, deposit_vault, account, deposit_param
 // );
 }
 
@@ -34,9 +34,7 @@ fn given_unsufficient_wnt_amount_for_deposit_then_fails() {
     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
     let account: ContractAddress = 'account'.try_into().unwrap();
     let deposit_param = create_dummy_deposit_param();
-    let key = create_deposit(
-        data_store, event_emitter, deposit_vault, chain, account, deposit_param
-    );
+    let key = create_deposit(data_store, event_emitter, deposit_vault, account, deposit_param);
 }
 
 // #[test]
@@ -61,7 +59,7 @@ fn given_normal_conditions_when_cancel_deposit_then_works() {
     let starting_gas = 2;
     let reason_bytes = array!['reason_bytes_1', 'reason_bytes_2',];
 // let key = create_deposit(
-//     data_store, event_emitter, deposit_vault, chain, account, deposit_param
+//     data_store, event_emitter, deposit_vault, account, deposit_param
 // );
 
 // cancel_deposit(

--- a/src/tests/deposit/test_deposit_utils.cairo
+++ b/src/tests/deposit/test_deposit_utils.cairo
@@ -138,7 +138,7 @@ fn create_dummy_deposit_param() -> CreateDepositParams {
         /// to the user in case the deposit gets cancelled.
         should_unwrap_native_token: false,
         /// The execution fee for keepers.
-        execution_fee: 0,
+        execution_fee: 1,
         /// The gas limit for the callback_contract.
         callback_gas_limit: 20
     }

--- a/src/tests/deposit/test_deposit_utils.cairo
+++ b/src/tests/deposit/test_deposit_utils.cairo
@@ -1,3 +1,149 @@
 //! Test file for `src/deposit/deposit_utils.cairo`.
+use starknet::{ContractAddress, contract_address_const};
 
+use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
+use satoru::role::role_store::{IRoleStoreDispatcher, IRoleStoreDispatcherTrait};
+use satoru::event::event_emitter::{IEventEmitterDispatcher, IEventEmitterDispatcherTrait};
+use satoru::chain::chain::{IChainDispatcher, IChainDispatcherTrait};
+use satoru::role::role;
+use satoru::tests_lib;
+use satoru::utils::span32::{Span32, Array32Trait};
+use satoru::deposit::{
+    deposit::Deposit, deposit_utils::CreateDepositParams, deposit_utils::create_deposit,
+    deposit_utils::cancel_deposit,
+    deposit_vault::{IDepositVaultDispatcher, IDepositVaultDispatcherTrait}
+};
+
+use snforge_std::{declare, start_prank, ContractClassTrait};
+
+
+#[test]
+fn should_create_deposit() {
+    let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
+    let account: ContractAddress = 'account'.try_into().unwrap();
+    let deposit_param = create_dummy_deposit_param();
+// let key = create_deposit(
+//     data_store, event_emitter, deposit_vault, chain, account, deposit_param
+// );
+}
+
+
+#[test]
+#[should_panic(expected: ('insffcient_wnt_amt_for_exec_fee',))]
+fn should_panic_if_unsufficient_wnt_amount_for_deposit() {
+    let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
+    let account: ContractAddress = 'account'.try_into().unwrap();
+    let deposit_param = create_dummy_deposit_param();
+    let key = create_deposit(
+        data_store, event_emitter, deposit_vault, chain, account, deposit_param
+    );
+}
+
+// #[test]
+// #[should_panic(expected: ('empty_deposit_amounts',))]
+// fn should_panic_on_empty_deposit_amount() {
+//     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
+//     let account: ContractAddress = 'account'.try_into().unwrap();
+//     let deposit_param = create_dummy_deposit_param();
+//     let key = create_deposit(
+//         data_store, event_emitter, deposit_vault, chain, account, deposit_param
+//     );
+// }
+
+
+#[test]
+fn should_cancel_deposit() {
+    let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
+    let account: ContractAddress = 'account'.try_into().unwrap();
+    let keeper: ContractAddress = 'keeper'.try_into().unwrap();
+    let deposit_param = create_dummy_deposit_param();
+    let key = 'key';
+    let reason = 'key';
+    let starting_gas = 2;
+    let reason_bytes = array!['reason_bytes_1', 'reason_bytes_2',];
+// let key = create_deposit(
+//     data_store, event_emitter, deposit_vault, chain, account, deposit_param
+// );
+
+// cancel_deposit(
+//     data_store, event_emitter, deposit_vault, key, keeper, starting_gas, reason, reason_bytes
+// );
+}
+
+
+/// Utility function to setup the test environment.
+///
+/// # Returns
+///
+/// * `ContractAddress` - The address of the caller.
+/// * `IDataStoreDispatcher` - The data store dispatcher.
+/// * `IRoleStoreDispatcher` - The role store dispatcher.
+fn setup() -> (
+    ContractAddress,
+    IDataStoreDispatcher,
+    IEventEmitterDispatcher,
+    IDepositVaultDispatcher,
+    IChainDispatcher
+) {
+    let (caller_address, role_store, data_store) = tests_lib::setup();
+    let (_, event_emitter) = tests_lib::setup_event_emitter();
+    let deposit_vault_address = deploy_deposit_vault(
+        data_store.contract_address, role_store.contract_address
+    );
+    let deposit_vault = IDepositVaultDispatcher { contract_address: deposit_vault_address };
+
+    let chain_address = deploy_chain();
+    let chain = IChainDispatcher { contract_address: chain_address };
+    (caller_address, data_store, event_emitter, deposit_vault, chain)
+}
+
+/// Utility function to deploy a `DepositVault` contract and return its dispatcher.
+fn deploy_deposit_vault(
+    data_store_address: ContractAddress, role_store_address: ContractAddress
+) -> ContractAddress {
+    let contract = declare('DepositVault');
+    contract.deploy(@array![data_store_address.into(), role_store_address.into()]).unwrap()
+}
+
+/// Utility function to deploy a `Chain` contract and return its dispatcher.
+fn deploy_chain() -> ContractAddress {
+    let contract = declare('Chain');
+    contract.deploy(@array![]).unwrap()
+}
+
+fn create_dummy_deposit_param() -> CreateDepositParams {
+    CreateDepositParams {
+        /// The address to send the market tokens to.
+        receiver: 'receiver'.try_into().unwrap(),
+        /// The callback contract linked to this deposit.
+        callback_contract: 'callback_contract'.try_into().unwrap(),
+        /// The ui fee receiver.
+        ui_fee_receiver: 'ui_fee_receiver'.try_into().unwrap(),
+        /// The market to deposit into.
+        market: 'market'.try_into().unwrap(),
+        /// The initial long token address.
+        initial_long_token: 'initial_long_token'.try_into().unwrap(),
+        /// The initial short token address.
+        initial_short_token: 'initial_short_token'.try_into().unwrap(),
+        /// The swap path into markets for the long token.
+        long_token_swap_path: array![
+            1.try_into().unwrap(), 2.try_into().unwrap(), 3.try_into().unwrap()
+        ]
+            .span32(),
+        /// The swap path into markets for the short token.
+        short_token_swap_path: array![
+            4.try_into().unwrap(), 5.try_into().unwrap(), 6.try_into().unwrap()
+        ]
+            .span32(),
+        /// The minimum acceptable number of liquidity tokens.
+        min_market_tokens: 10,
+        /// Whether to unwrap the native token when sending funds back
+        /// to the user in case the deposit gets cancelled.
+        should_unwrap_native_token: false,
+        /// The execution fee for keepers.
+        execution_fee: 0,
+        /// The gas limit for the callback_contract.
+        callback_gas_limit: 20
+    }
+}
 

--- a/src/tests/event/test_withdrawal_events_emitted.cairo
+++ b/src/tests/event/test_withdrawal_events_emitted.cairo
@@ -35,8 +35,7 @@ fn given_normal_conditions_when_emit_withdrawal_created_then_works() {
         withdrawal.min_long_token_amount.into(),
         withdrawal.min_short_token_amount.into(),
         withdrawal.updated_at_block.into(),
-        withdrawal.execution_fee.low.into(),
-        withdrawal.execution_fee.high.into(),
+        withdrawal.execution_fee.into(),
         withdrawal.callback_gas_limit.into(),
         withdrawal.should_unwrap_native_token.into(),
     ];

--- a/src/withdrawal/withdrawal.cairo
+++ b/src/withdrawal/withdrawal.cairo
@@ -41,7 +41,7 @@ struct Withdrawal {
     /// The block at which the withdrawal was last updated.
     updated_at_block: u64,
     /// The execution fee for the withdrawal.
-    execution_fee: u256,
+    execution_fee: u128,
     /// The gas limit for calling the callback contract.
     callback_gas_limit: u128,
     /// whether to unwrap the native token

--- a/src/withdrawal/withdrawal_utils.cairo
+++ b/src/withdrawal/withdrawal_utils.cairo
@@ -53,7 +53,7 @@ struct CreateWithdrawalParams {
     /// Whether the native token should be unwrapped when executing the withdrawal.
     should_unwrap_native_token: bool,
     /// The execution fee for the withdrawal.
-    execution_fee: u256,
+    execution_fee: u128,
     /// The gas limit for calling the callback contract.
     callback_gas_limit: u128,
 }
@@ -129,10 +129,8 @@ fn create_withdrawal(
 
     let wnt_amount = withdrawal_vault.record_transfer_in(wnt);
 
-    if wnt_amount < params.execution_fee.try_into().unwrap() {
-        WithdrawalError::INSUFFICIENT_WNT_AMOUNT(
-            wnt_amount, params.execution_fee.try_into().unwrap()
-        );
+    if wnt_amount < params.execution_fee {
+        WithdrawalError::INSUFFICIENT_WNT_AMOUNT(wnt_amount, params.execution_fee);
     }
 
     account_utils::validate_receiver(params.receiver);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:


- Feature deposit_utils


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: https://github.com/keep-starknet-strange/satoru/issues/353

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- create_deposit and cancel_deposit are implemented for now without test. Waiting for next foundry version.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

- Update deposit struct to use u128 and u64 for updated_at_block
- Update gas_utils::validate_execution_fee to use u128
- Add new function gas_utils::pay_execution_fee_deposit similiar to gas_utils::pay_execution_fee but taking as parameter IDepositVaultDispatcher
- Contract class for tests created but need next foundry version to simulate call to record_transfer_in,validate_callback_gas_limit,transfer_out



