### PR TITLE
dev: refactor wnt to fee_token

### DIFF
--- a/src/adl/adl_utils.cairo
+++ b/src/adl/adl_utils.cairo
@@ -189,7 +189,6 @@ fn create_adl_order(params: CreateAdlOrderParams) -> felt252 {
         min_output_amount: 0,
         updated_at_block: params.updated_at_block,
         is_long: position.is_long,
-        should_unwrap_native_token: true,
         is_frozen: false,
     };
     params.data_store.set_order(key, order);

--- a/src/data/keys.cairo
+++ b/src/data/keys.cairo
@@ -11,9 +11,9 @@ use poseidon::poseidon_hash_span;
 // *                        CONSTANT KEYS                                  *
 // *************************************************************************
 
-/// Key for the address of the wrapped native token.
-fn wnt() -> felt252 {
-    hash_poseidon_single('WNT')
+/// Key for the address of the fee token.
+fn fee_token() -> felt252 {
+    hash_poseidon_single('FEE_TOKEN')
 }
 
 /// Key for the nonce value used in NonceUtils.

--- a/src/deposit/deposit_utils.cairo
+++ b/src/deposit/deposit_utils.cairo
@@ -91,7 +91,8 @@ fn create_deposit(
     } else {
         let fee_token_amount = deposit_vault.record_transfer_in(fee_token);
         assert(
-            fee_token_amount >= params.execution_fee, GasError::INSUFFICIENT_FEE_TOKEN_AMOUNT_FOR_EXECUTION_FEE
+            fee_token_amount >= params.execution_fee,
+            GasError::INSUFFICIENT_FEE_TOKEN_AMOUNT_FOR_EXECUTION_FEE
         );
 
         params.execution_fee = fee_token_amount;

--- a/src/deposit/deposit_utils.cairo
+++ b/src/deposit/deposit_utils.cairo
@@ -48,9 +48,6 @@ struct CreateDepositParams {
     short_token_swap_path: Span32<ContractAddress>,
     /// The minimum acceptable number of liquidity tokens.
     min_market_tokens: u128,
-    /// Whether to unwrap the native token when sending funds back
-    /// to the user in case the deposit gets cancelled.
-    should_unwrap_native_token: bool,
     /// The execution fee for keepers.
     execution_fee: u128,
     /// The gas limit for the callback_contract.
@@ -85,19 +82,19 @@ fn create_deposit(
     let mut initial_short_token_amount = deposit_vault
         .record_transfer_in(params.initial_short_token);
 
-    let wnt: ContractAddress = token_utils::wnt(data_store);
+    let fee_token: ContractAddress = token_utils::fee_token(data_store);
 
-    if params.initial_long_token == wnt {
+    if params.initial_long_token == fee_token {
         initial_long_token_amount -= params.execution_fee;
-    } else if params.initial_short_token == wnt {
+    } else if params.initial_short_token == fee_token {
         initial_short_token_amount -= params.execution_fee;
     } else {
-        let wnt_amount = deposit_vault.record_transfer_in(wnt);
+        let fee_token_amount = deposit_vault.record_transfer_in(fee_token);
         assert(
-            wnt_amount >= params.execution_fee, GasError::INSUFFICIENT_WNT_AMOUNT_FOR_EXECUTION_FEE
+            fee_token_amount >= params.execution_fee, GasError::INSUFFICIENT_FEE_TOKEN_AMOUNT_FOR_EXECUTION_FEE
         );
 
-        params.execution_fee = wnt_amount;
+        params.execution_fee = fee_token_amount;
     }
 
     assert(

--- a/src/event/event_emitter.cairo
+++ b/src/event/event_emitter.cairo
@@ -872,7 +872,6 @@ mod EventEmitter {
         updated_at_block: u64,
         execution_fee: u128,
         callback_gas_limit: u128,
-        should_unwrap_native_token: bool
     }
 
     #[derive(Drop, starknet::Event)]
@@ -1677,7 +1676,6 @@ mod EventEmitter {
                         updated_at_block: withdrawal.updated_at_block,
                         execution_fee: withdrawal.execution_fee,
                         callback_gas_limit: withdrawal.callback_gas_limit,
-                        should_unwrap_native_token: withdrawal.should_unwrap_native_token
                     }
                 );
         }

--- a/src/exchange/order_handler.cairo
+++ b/src/exchange/order_handler.cairo
@@ -30,7 +30,7 @@ trait IOrderHandler<TContractState> {
     /// Updates the given order with the specified size delta, acceptable price, and trigger price.
     /// The `updateOrder()` feature must be enabled for the given order type. The caller must be the owner
     /// of the order, and the order must not be a market order. The size delta, trigger price, and
-    /// acceptable price are updated on the order, and the order is unfrozen. Any additional WNT that is
+    /// acceptable price are updated on the order, and the order is unfrozen. Any additional FEE_TOKEN that is
     /// transferred to the contract is added to the order's execution fee. The updated order is then saved
     /// in the order store, and an `OrderUpdated` event is emitted.
     ///
@@ -262,10 +262,10 @@ mod OrderHandler {
             updated_order.is_frozen = false;
 
             // Allow topping up of execution fee as frozen orders will have execution fee reduced.
-            let wnt = token_utils::wnt(data_store);
+            let fee_token = token_utils::fee_token(data_store);
             let order_vault = base_order_handler_state.order_vault.read();
-            let received_wnt = order_vault.record_transfer_in(wnt);
-            updated_order.execution_fee = received_wnt;
+            let received_fee_token = order_vault.record_transfer_in(fee_token);
+            updated_order.execution_fee = received_fee_token;
 
             let estimated_gas_limit = gas_utils::estimate_execute_order_gas_limit(
                 data_store, @updated_order

--- a/src/gas/error.cairo
+++ b/src/gas/error.cairo
@@ -1,3 +1,3 @@
 mod GasError {
-    const INSUFFICIENT_WNT_AMOUNT_FOR_EXECUTION_FEE: felt252 = 'insffcient_wnt_amt_for_exec_fee';
+    const INSUFFICIENT_FEE_TOKEN_AMOUNT_FOR_EXECUTION_FEE: felt252 = 'insffcient_tok_amt_for_exec_fee';
 }

--- a/src/gas/error.cairo
+++ b/src/gas/error.cairo
@@ -1,3 +1,4 @@
 mod GasError {
-    const INSUFFICIENT_FEE_TOKEN_AMOUNT_FOR_EXECUTION_FEE: felt252 = 'insffcient_tok_amt_for_exec_fee';
+    const INSUFFICIENT_FEE_TOKEN_AMOUNT_FOR_EXECUTION_FEE: felt252 =
+        'insffcient_tok_amt_for_exec_fee';
 }

--- a/src/order/base_order_utils.cairo
+++ b/src/order/base_order_utils.cairo
@@ -104,8 +104,6 @@ struct CreateOrderParams {
     decrease_position_swap_type: DecreasePositionSwapType,
     /// Whether the order is for a long or short.
     is_long: bool,
-    /// Whether to unwrap native tokens before transferring to the user.
-    should_unwrap_native_token: bool,
     /// The referral code linked to this order.
     referral_code: felt252
 }
@@ -129,7 +127,6 @@ impl CreateOrderParamsClone of Clone<CreateOrderParams> {
             order_type: *self.order_type,
             decrease_position_swap_type: *self.decrease_position_swap_type,
             is_long: *self.is_long,
-            should_unwrap_native_token: *self.should_unwrap_native_token,
             referral_code: *self.referral_code
         }
     }

--- a/src/order/order.cairo
+++ b/src/order/order.cairo
@@ -56,8 +56,6 @@ struct Order {
     updated_at_block: u64,
     /// Whether the order is for a long or short.
     is_long: bool,
-    /// Whether to unwrap native tokens before transferring to the user.
-    should_unwrap_native_token: bool,
     /// Whether the order is frozen.
     is_frozen: bool,
 }
@@ -84,7 +82,6 @@ impl DefaultOrder of Default<Order> {
             min_output_amount: 0,
             updated_at_block: 0,
             is_long: true,
-            should_unwrap_native_token: true,
             is_frozen: true,
         }
     }

--- a/src/position/decrease_position_swap_utils.cairo
+++ b/src/position/decrease_position_swap_utils.cairo
@@ -47,7 +47,6 @@ fn swap_withdrawn_collateral_to_pnl_token(
                     min_output_amount: 0,
                     receiver: params.market.market_token,
                     ui_fee_receiver: params.order.ui_fee_receiver,
-                    should_unwrap_native_token: false
                 }
             );
 
@@ -93,7 +92,6 @@ fn swap_profit_to_collateral_token(
                     min_output_amount: 0,
                     receiver: params.market.market_token,
                     ui_fee_receiver: params.order.ui_fee_receiver,
-                    should_unwrap_native_token: false
                 }
             );
         return (true, swap_output_amount);

--- a/src/router/exchange_router.cairo
+++ b/src/router/exchange_router.cairo
@@ -32,12 +32,6 @@ use satoru::exchange::{
 // *************************************************************************
 #[starknet::interface]
 trait IExchangeRouter<TContractState> {
-    /// Wraps the specified amount of native tokens into WNT then sends the WNT to the specified address.
-    /// # Arguments
-    /// * `receiver` - The address of the receiver.
-    /// * `amount` - The amount of tokens to transfer.
-    fn send_wnt(ref self: TContractState, receiver: ContractAddress, amount: u128);
-
     /// Sends the given amount of tokens to the given address.
     /// # Arguments
     /// * `token` - The token address to transfer.
@@ -271,9 +265,6 @@ mod ExchangeRouter {
     // *************************************************************************
     #[external(v0)]
     impl ExchangeRouterImpl of super::IExchangeRouter<ContractState> {
-        fn send_wnt(ref self: ContractState, receiver: ContractAddress, amount: u128) { //TODO
-        }
-
         fn send_tokens(
             ref self: ContractState, token: ContractAddress, receiver: ContractAddress, amount: u128
         ) { //TODO

--- a/src/swap/swap_utils.cairo
+++ b/src/swap/swap_utils.cairo
@@ -49,9 +49,6 @@ struct SwapParams {
     receiver: ContractAddress,
     /// The address of the ui fee receiver.
     ui_fee_receiver: ContractAddress,
-    /// A boolean indicating whether the received tokens should be unwrapped from
-    /// the wrapped native token (WNT) if they are wrapped.
-    should_unwrap_native_token: bool,
 }
 
 impl DefaultSwapParams of Default<SwapParams> {
@@ -69,7 +66,6 @@ impl DefaultSwapParams of Default<SwapParams> {
             min_output_amount: 0,
             receiver: contract_address,
             ui_fee_receiver: contract_address,
-            should_unwrap_native_token: false,
         }
     }
 }
@@ -84,9 +80,6 @@ struct _SwapParams {
     amount_in: u128,
     /// The address to which the swapped tokens should be sent.
     receiver: ContractAddress,
-    /// A boolean indicating whether the received tokens should be unwrapped from
-    /// the wrapped native token (WNT) if they are wrapped.
-    should_unwrap_native_token: bool,
 }
 
 #[derive(Default, Drop, Copy, starknet::Store, Serde)]
@@ -161,11 +154,6 @@ fn swap(params: @SwapParams) -> (ContractAddress, u128) {
             token_in: token_out,
             amount_in: output_amount,
             receiver: receiver,
-            should_unwrap_native_token: if (i == array_length - 1) {
-                *params.should_unwrap_native_token
-            } else {
-                false
-            }
         };
         let (_token_out_res, _output_amount_res) = _swap(params, @_params);
         token_out = _token_out_res;

--- a/src/swap/swap_utils.cairo
+++ b/src/swap/swap_utils.cairo
@@ -150,10 +150,7 @@ fn swap(params: @SwapParams) -> (ContractAddress, u128) {
             *params.receiver
         };
         let _params = _SwapParams {
-            market: market,
-            token_in: token_out,
-            amount_in: output_amount,
-            receiver: receiver,
+            market: market, token_in: token_out, amount_in: output_amount, receiver: receiver,
         };
         let (_token_out_res, _output_amount_res) = _swap(params, @_params);
         token_out = _token_out_res;

--- a/src/tests/data/test_keys.cairo
+++ b/src/tests/data/test_keys.cairo
@@ -3,8 +3,8 @@ use starknet::{ContractAddress, contract_address_const};
 
 #[test]
 fn given_constant_keys_when_tested_then_expected_results() {
-    let wnt = keys::wnt();
-    assert(wnt == 0x74d98a44e50c39f5a55e16dec65fc43c09ca04efa146e762ab2e4cf8a02ae0e, 'wrong_key');
+    let fee_token = keys::fee_token();
+    assert(fee_token == 0x74d98a44e50c39f5a55e16dec65fc43c09ca04efa146e762ab2e4cf8a02ae0e, 'wrong_key'); //change?
 
     let account_1: ContractAddress = contract_address_const::<1>();
     let account_deposit_list_key_account_1 = keys::account_deposit_list_key(account_1);

--- a/src/tests/data/test_keys.cairo
+++ b/src/tests/data/test_keys.cairo
@@ -4,7 +4,9 @@ use starknet::{ContractAddress, contract_address_const};
 #[test]
 fn given_constant_keys_when_tested_then_expected_results() {
     let fee_token = keys::fee_token();
-    assert(fee_token == 0x74d98a44e50c39f5a55e16dec65fc43c09ca04efa146e762ab2e4cf8a02ae0e, 'wrong_key'); //change?
+    assert(
+        fee_token == 0x74d98a44e50c39f5a55e16dec65fc43c09ca04efa146e762ab2e4cf8a02ae0e, 'wrong_key'
+    ); //change?
 
     let account_1: ContractAddress = contract_address_const::<1>();
     let account_deposit_list_key_account_1 = keys::account_deposit_list_key(account_1);

--- a/src/tests/data/test_keys.cairo
+++ b/src/tests/data/test_keys.cairo
@@ -3,10 +3,11 @@ use starknet::{ContractAddress, contract_address_const};
 
 #[test]
 fn given_constant_keys_when_tested_then_expected_results() {
-    let fee_token = keys::fee_token();
+    let fee_token_key = keys::fee_token();
     assert(
-        fee_token == 0x74d98a44e50c39f5a55e16dec65fc43c09ca04efa146e762ab2e4cf8a02ae0e, 'wrong_key'
-    ); //change?
+        fee_token_key == 0x32251f2c8577168e89dfd8e561b2f327cd63d892a6d58f90955cf548db4f64f,
+        'wrong_key'
+    );
 
     let account_1: ContractAddress = contract_address_const::<1>();
     let account_deposit_list_key_account_1 = keys::account_deposit_list_key(account_1);

--- a/src/tests/data/test_order.cairo
+++ b/src/tests/data/test_order.cairo
@@ -23,7 +23,6 @@ fn given_normal_conditions_when_set_order_new_and_override_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -82,7 +81,6 @@ fn given_order_account_0_when_set_order_then_fails() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -111,7 +109,6 @@ fn given_caller_not_controller_when_set_order_then_fails() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -139,7 +136,6 @@ fn given_caller_not_controller_when_get_order_keys_then_fails() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -177,7 +173,6 @@ fn given_normal_conditions_when_remove_only_order_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -217,7 +212,6 @@ fn given_normal_conditions_when_remove_1_of_n_order_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -231,7 +225,6 @@ fn given_normal_conditions_when_remove_1_of_n_order_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -282,7 +275,6 @@ fn given_caller_not_controller_when_remove_order_then_fails() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -318,7 +310,6 @@ fn given_normal_conditions_when_multiple_account_keys_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -332,7 +323,6 @@ fn given_normal_conditions_when_multiple_account_keys_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 2
     );
@@ -344,7 +334,6 @@ fn given_normal_conditions_when_multiple_account_keys_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -356,7 +345,6 @@ fn given_normal_conditions_when_multiple_account_keys_then_works() {
         contract_address_const::<'market1'>(),
         contract_address_const::<'token1'>(),
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false,
         order_no: 1
     );
@@ -418,7 +406,6 @@ fn given_normal_conditions_when_multiple_account_keys_then_works() {
 /// * `market` - The trading market.
 /// * `initial_collateral_token` - The initial collateral token for increase orders.
 /// * `is_long` - Whether the order is for a long or short.
-/// * `should_unwrap_native_token` - Whether to unwrap native tokens before transferring to the user.
 /// * `is_frozen` - Whether the order is frozen.
 /// * `order_no` - Random number to change values
 fn create_new_order(
@@ -428,7 +415,6 @@ fn create_new_order(
     market: ContractAddress,
     initial_collateral_token: ContractAddress,
     is_long: bool,
-    should_unwrap_native_token: bool,
     is_frozen: bool,
     order_no: u128
 ) -> Order {
@@ -471,7 +457,6 @@ fn create_new_order(
         min_output_amount,
         updated_at_block,
         is_long,
-        should_unwrap_native_token,
         is_frozen,
     }
 }

--- a/src/tests/data/test_withdrawal.cairo
+++ b/src/tests/data/test_withdrawal.cairo
@@ -85,7 +85,6 @@ fn given_normal_conditions_when_set_withdrawal_new_and_override_then_works() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
 
     // Test logic
@@ -153,7 +152,6 @@ fn given_withdrawal_account_0_when_set_withdrawal_then_fails() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
 
     // Test logic
@@ -197,7 +195,6 @@ fn given_caller_not_controller_when_set_withdrawal_then_fails() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
 
     // Test logic
@@ -241,7 +238,6 @@ fn given_caller_not_controller_when_get_withdrawal_keys_then_fails() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
     data_store.set_withdrawal(key, withdrawal);
 
@@ -290,7 +286,6 @@ fn given_normal_conditions_when_remove_only_withdrawal_then_works() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
 
     data_store.set_withdrawal(key, withdrawal);
@@ -342,7 +337,6 @@ fn given_normal_conditions_when_remove_1_of_n_withdrawal_then_works() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
 
     let key_2: felt252 = 987654321;
@@ -361,7 +355,6 @@ fn given_normal_conditions_when_remove_1_of_n_withdrawal_then_works() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
 
     data_store.set_withdrawal(key_1, withdrawal_1);
@@ -420,7 +413,6 @@ fn given_caller_not_controller_when_remove_withdrawal_then_fails() {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     };
     data_store.set_withdrawal(key, withdrawal);
 

--- a/src/tests/deposit/test_deposit_utils.cairo
+++ b/src/tests/deposit/test_deposit_utils.cairo
@@ -29,8 +29,8 @@ fn given_normal_conditions_when_deposit_then_works() {
 
 
 #[test]
-#[should_panic(expected: ('insffcient_wnt_amt_for_exec_fee',))]
-fn given_unsufficient_wnt_amount_for_deposit_then_fails() {
+#[should_panic(expected: ('insffcient_tok_amt_for_exec_fee',))]
+fn given_unsufficient_fee_token_amount_for_deposit_then_fails() {
     let (caller_address, data_store, event_emitter, deposit_vault, chain) = setup();
     let account: ContractAddress = 'account'.try_into().unwrap();
     let deposit_param = create_dummy_deposit_param();
@@ -134,9 +134,6 @@ fn create_dummy_deposit_param() -> CreateDepositParams {
             .span32(),
         /// The minimum acceptable number of liquidity tokens.
         min_market_tokens: 10,
-        /// Whether to unwrap the native token when sending funds back
-        /// to the user in case the deposit gets cancelled.
-        should_unwrap_native_token: false,
         /// The execution fee for keepers.
         execution_fee: 1,
         /// The gas limit for the callback_contract.

--- a/src/tests/event/test_callback_events_emitted.cairo
+++ b/src/tests/event/test_callback_events_emitted.cairo
@@ -316,7 +316,6 @@ fn create_dummy_withdrawal() -> Withdrawal {
         updated_at_block: 40,
         execution_fee: 50,
         callback_gas_limit: 60,
-        should_unwrap_native_token: false,
     }
 }
 
@@ -345,7 +344,6 @@ fn create_dummy_order(key: felt252) -> Order {
         min_output_amount: 100,
         updated_at_block: 0,
         is_long: true,
-        should_unwrap_native_token: false,
         is_frozen: false,
     }
 }

--- a/src/tests/event/test_order_events_emitted.cairo
+++ b/src/tests/event/test_order_events_emitted.cairo
@@ -342,7 +342,6 @@ fn create_dummy_order(key: felt252) -> Order {
         min_output_amount: 100,
         updated_at_block: 0,
         is_long: true,
-        should_unwrap_native_token: false,
         is_frozen: false,
     }
 }

--- a/src/tests/event/test_withdrawal_events_emitted.cairo
+++ b/src/tests/event/test_withdrawal_events_emitted.cairo
@@ -37,7 +37,6 @@ fn given_normal_conditions_when_emit_withdrawal_created_then_works() {
         withdrawal.updated_at_block.into(),
         withdrawal.execution_fee.into(),
         withdrawal.callback_gas_limit.into(),
-        withdrawal.should_unwrap_native_token.into(),
     ];
 
     // Emit the event.
@@ -154,6 +153,5 @@ fn create_dummy_withdrawal(key: felt252) -> Withdrawal {
         updated_at_block: 1,
         execution_fee: 1,
         callback_gas_limit: 1,
-        should_unwrap_native_token: true,
     }
 }

--- a/src/tests/exchange/test_withdrawal_handler.cairo
+++ b/src/tests/exchange/test_withdrawal_handler.cairo
@@ -43,7 +43,6 @@ fn given_normal_conditions_when_create_withdrawal_then_works() {
         short_token_swap_path: Default::default(),
         min_long_token_amount: Default::default(),
         min_short_token_amount: Default::default(),
-        should_unwrap_native_token: Default::default(),
         execution_fee: Default::default(),
         callback_gas_limit: Default::default(),
     };
@@ -68,7 +67,6 @@ fn given_caller_not_controller_when_create_withdrawal_then_fails() {
         short_token_swap_path: Default::default(),
         min_long_token_amount: Default::default(),
         min_short_token_amount: Default::default(),
-        should_unwrap_native_token: Default::default(),
         execution_fee: Default::default(),
         callback_gas_limit: Default::default(),
     };
@@ -93,7 +91,6 @@ fn given_normal_conditions_when_cancel_withdrawal_then_works() {
         updated_at_block: Default::default(),
         execution_fee: Default::default(),
         callback_gas_limit: Default::default(),
-        should_unwrap_native_token: Default::default(),
     };
 
     let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
@@ -124,7 +121,6 @@ fn given_unexisting_key_when_cancel_withdrawal_then_fails() {
         updated_at_block: Default::default(),
         execution_fee: Default::default(),
         callback_gas_limit: Default::default(),
-        should_unwrap_native_token: Default::default(),
     };
 
     let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();

--- a/src/tests/order/test_order.cairo
+++ b/src/tests/order/test_order.cairo
@@ -74,7 +74,6 @@ fn create_dummy_order() -> Order {
         min_output_amount: 100,
         updated_at_block: 0,
         is_long: true,
-        should_unwrap_native_token: false,
         is_frozen: false,
     }
 }

--- a/src/tests/position/test_decrease_position_swap_utils.cairo
+++ b/src/tests/position/test_decrease_position_swap_utils.cairo
@@ -172,7 +172,6 @@ fn create_new_update_position_params(
         min_output_amount: 10,
         updated_at_block: 1,
         is_long: false,
-        should_unwrap_native_token: false,
         is_frozen: false
     };
 

--- a/src/tests/swap/test_swap_handler.cairo
+++ b/src/tests/swap/test_swap_handler.cairo
@@ -154,7 +154,6 @@ fn given_caller_not_controller_when_swap_then_fails() {
         min_output_amount: 1,
         receiver: contract_address_const::<'receiver'>(),
         ui_fee_receiver: contract_address_const::<'ui_fee_receiver'>(),
-        should_unwrap_native_token: true,
     };
 
     swap_handler.swap(swap);
@@ -187,7 +186,6 @@ fn given_normal_conditions_when_swap_then_works() {
         min_output_amount: 1,
         receiver: contract_address_const::<'receiver'>(),
         ui_fee_receiver: contract_address_const::<'ui_fee_receiver'>(),
-        should_unwrap_native_token: true,
     };
 
     let swap_result = swap_handler.swap(swap);

--- a/src/token/token_utils.cairo
+++ b/src/token/token_utils.cairo
@@ -9,7 +9,7 @@ use satoru::bank::error::BankError;
 use integer::u256_from_felt252;
 
 
-fn wnt(data_store: IDataStoreDispatcher) -> ContractAddress {
+fn fee_token(data_store: IDataStoreDispatcher) -> ContractAddress {
     // TODO
     ContractAddressZeroable::zero()
 }

--- a/src/withdrawal/error.cairo
+++ b/src/withdrawal/error.cairo
@@ -5,8 +5,8 @@ mod WithdrawalError {
     const EMPTY_WITHDRAWAL_AMOUNT: felt252 = 'empty withdrawal amount';
     const EMPTY_WITHDRAWAL: felt252 = 'empty withdrawal';
 
-    fn INSUFFICIENT_WNT_AMOUNT(data_1: u128, data_2: u128) {
-        panic(array!['insufficient wnt amout', data_1.into(), data_2.into()])
+    fn INSUFFICIENT_FEE_TOKEN_AMOUNT(data_1: u128, data_2: u128) {
+        panic(array!['insufficient fee token amout', data_1.into(), data_2.into()])
     }
 
     fn INSUFFICIENT_MARKET_TOKENS(data_1: u128, data_2: u128) {

--- a/src/withdrawal/withdrawal.cairo
+++ b/src/withdrawal/withdrawal.cairo
@@ -44,8 +44,6 @@ struct Withdrawal {
     execution_fee: u128,
     /// The gas limit for calling the callback contract.
     callback_gas_limit: u128,
-    /// whether to unwrap the native token
-    should_unwrap_native_token: bool,
 }
 
 impl DefaultWithdrawal of Default<Withdrawal> {
@@ -65,7 +63,6 @@ impl DefaultWithdrawal of Default<Withdrawal> {
             updated_at_block: 0,
             execution_fee: 0,
             callback_gas_limit: 0,
-            should_unwrap_native_token: true,
         }
     }
 }

--- a/src/withdrawal/withdrawal_vault.cairo
+++ b/src/withdrawal/withdrawal_vault.cairo
@@ -22,7 +22,6 @@ trait IWithdrawalVault<TContractState> {
         token: ContractAddress,
         receiver: ContractAddress,
         amount: u128,
-        should_unwrap_native_token: bool
     );
     fn sync_token_balance(ref self: TContractState, token: ContractAddress) -> u128;
 }
@@ -90,7 +89,6 @@ mod WithdrawalVault {
             token: ContractAddress,
             receiver: ContractAddress,
             amount: u128,
-            should_unwrap_native_token: bool
         ) {}
 
         fn sync_token_balance(ref self: ContractState, token: ContractAddress) -> u128 {

--- a/src/withdrawal/withdrawal_vault.cairo
+++ b/src/withdrawal/withdrawal_vault.cairo
@@ -18,10 +18,7 @@ trait IWithdrawalVault<TContractState> {
     fn initialize(ref self: TContractState, strict_bank_address: ContractAddress,);
     fn record_transfer_in(ref self: TContractState, token: ContractAddress) -> u128;
     fn transfer_out(
-        ref self: TContractState,
-        token: ContractAddress,
-        receiver: ContractAddress,
-        amount: u128,
+        ref self: TContractState, token: ContractAddress, receiver: ContractAddress, amount: u128,
     );
     fn sync_token_balance(ref self: TContractState, token: ContractAddress) -> u128;
 }


### PR DESCRIPTION
Since we are considering ETH erc20 to be the equivalent of "native token", it's probably a good idea to correct the terminology used throughout the code base.

# Pull Request type
- Refactoring (no functional changes, no API changes)

## What is the current behavior?
Wrapped native token terminology used

Resolves: #442 

## What is the new behavior?
Terminology refactored to `fee_token`

## Does this introduce a breaking change?
No. It does however begin to differ from the gmx-synthetics repo

