### PR TITLE
Adding Role admin check to the role-admin branch

### DIFF
--- a/src/role/error.cairo
+++ b/src/role/error.cairo
@@ -1,3 +1,4 @@
 mod RoleError {
     const UNAUTHORIZED_ACCESS: felt252 = 'unauthorized_access';
+    const UNAUTHORIZED_CHANGE: felt252 = 'unauthorized_change';
 }

--- a/src/role/role_store.cairo
+++ b/src/role/role_store.cairo
@@ -81,6 +81,7 @@ mod RoleStore {
 
     // Local imports.
     use satoru::role::{role, error::RoleError};
+    
 
     // *************************************************************************
     // STORAGE
@@ -164,6 +165,10 @@ mod RoleStore {
         fn revoke_role(ref self: ContractState, account: ContractAddress, role_key: felt252) {
             // Check that the caller has the admin role.
             self._assert_only_role(get_caller_address(), role::ROLE_ADMIN);
+            // check that the are more than 1 RoleAdmin
+            if role_key == role::ROLE_ADMIN {
+                assert(self.get_role_member_count(role_key) > 1, RoleError::UNAUTHORIZED_CHANGE);
+            }
             // Revoke the role.
             self._revoke_role(account, role_key);
         }

--- a/src/role/role_store.cairo
+++ b/src/role/role_store.cairo
@@ -81,7 +81,7 @@ mod RoleStore {
 
     // Local imports.
     use satoru::role::{role, error::RoleError};
-    
+
 
     // *************************************************************************
     // STORAGE

--- a/tests/role/test_role_store.cairo
+++ b/tests/role/test_role_store.cairo
@@ -43,7 +43,7 @@ fn given_normal_conditions_when_has_role_after_revoke_then_works() {
     assert(!role_store.has_role(account_1(), ROLE_ADMIN), 'Invalid role');
 }
 #[test]
-#[should_panic]
+#[should_panic(expected: ('unauthorized_change',))]
 fn given_normal_conditions_when_revoke_role_on_1_ROLE_ADMIN_panics() {
     let role_store = setup();
 
@@ -52,13 +52,10 @@ fn given_normal_conditions_when_revoke_role_on_1_ROLE_ADMIN_panics() {
     // assert that there is only one role ROLE_ADMIN present
     assert(role_store.get_role_member_count(ROLE_ADMIN) == 1, 'members count != 1');
 
-   
     // Check that the account address has the admin role.
     assert(role_store.has_role(admin(), ROLE_ADMIN), 'Invalid role');
     // Revoke role_admin should panic.
     role_store.revoke_role(admin(), ROLE_ADMIN);
-    
-    
 }
 
 

--- a/tests/role/test_role_store.cairo
+++ b/tests/role/test_role_store.cairo
@@ -42,6 +42,25 @@ fn given_normal_conditions_when_has_role_after_revoke_then_works() {
     // Check that the account address does not have the admin role.
     assert(!role_store.has_role(account_1(), ROLE_ADMIN), 'Invalid role');
 }
+#[test]
+#[should_panic]
+fn given_normal_conditions_when_revoke_role_on_1_ROLE_ADMIN_panics() {
+    let role_store = setup();
+
+    // Use the address that has been used to deploy role_store.
+    start_prank(role_store.contract_address, admin());
+    // assert that there is only one role ROLE_ADMIN present
+    assert(role_store.get_role_member_count(ROLE_ADMIN) == 1, 'members count != 1');
+
+   
+    // Check that the account address has the admin role.
+    assert(role_store.has_role(admin(), ROLE_ADMIN), 'Invalid role');
+    // Revoke role_admin should panic.
+    role_store.revoke_role(admin(), ROLE_ADMIN);
+    
+    
+}
+
 
 #[test]
 fn given_normal_conditions_when_get_role_count_then_works() {


### PR DESCRIPTION
## ISSUE
The `role_store.cairo` code allows for granting and revoking of roles. The only role allowed to do this, is the `ROLE_ADMIN`, therefore it is important that if the contract has only a single account of role `ROLE_ADMIN` then it should not be that the role is revoked, because:
1. The `_revoke_role` removes the role from roles if there is no members as seen here
``` cairo
 if self.get_role_member_count(role_key).is_zero() {
                    let role_index = self._find_role_index(role_key);
                    self.roles.write(role_index, Zeroable::zero());
                }
```
Meaning, that if we only have a single account as `ROLE_ADMIN` and revoke, it then, that role would be deleted and therefore future granting and revocation of roles would not be possible hence any future change is not possible.

#### Mitigation
With the aforementioned issue, I recommend we change the `revoke_role ()` function as follows:
```cairo
     fn revoke_role(ref self: ContractState, account: ContractAddress, role_key: felt252) {
            // Check that the caller has the admin role.
            self._assert_only_role(get_caller_address(), role::ROLE_ADMIN);
            // check that the are more than 1 RoleAdmin
            if role_key == role::ROLE_ADMIN {
                assert(self.get_role_member_count(role_key) > 1, RoleError::UNAUTHORIZED_CHANGE);
            }
            // Revoke the role.
            self._revoke_role(account, role_key);
        }
```
We add a new check, such that if the role being changes (`role_key)` is `==` to `ROLE_ADMIN` we assert that there are more than 1  accounts with `ROLE_ADMIN` then proceed, to avoid a scenario where we revoke and delete entirerly the `ROLE_ADMIN` as explained above

## Code Changes
1. I have added new piece of code to perform the check on `role_store.cairo` contract as follows
```cairo
  fn revoke_role(ref self: ContractState, account: ContractAddress, role_key: felt252) {
            // Check that the caller has the admin role.
            self._assert_only_role(get_caller_address(), role::ROLE_ADMIN);
            // check that the are more than 1 RoleAdmin
            if role_key == role::ROLE_ADMIN {
                assert(self.get_role_member_count(role_key) > 1, RoleError::UNAUTHORIZED_CHANGE);
            }
            // Revoke the role.
            self._revoke_role(account, role_key);
        }
```
2. I have added a new test case to test this new scenario in `test_role_store.cairo` as follows:
```cairo
#[test]
#[should_panic]
fn given_normal_conditions_when_revoke_role_on_1_ROLE_ADMIN_panics() {
    let role_store = setup();

    // Use the address that has been used to deploy role_store.
    start_prank(role_store.contract_address, admin());
    // assert that there is only one role ROLE_ADMIN present
    assert(role_store.get_role_member_count(ROLE_ADMIN) == 1, 'members count != 1');

   
    // Check that the account address has the admin role.
    assert(role_store.has_role(admin(), ROLE_ADMIN), 'Invalid role');
    // Revoke role_admin should panic.
    role_store.revoke_role(admin(), ROLE_ADMIN);
    
    
}
```
3. In `errors.cairo` I have defined another error `UNAUTHORIZED_CHANGE` as follows
```cairo
const UNAUTHORIZED_CHANGE: felt252 = 'unauthorized_change';
``` 
to be emitted anytime there is revocation of `ROLE_ADMIN` from the only `ROLE_ADMIN` account remaining. 

