### PR TITLE
test: Tests for deposit_vault

### DIFF
--- a/src/deposit/deposit_vault.cairo
+++ b/src/deposit/deposit_vault.cairo
@@ -80,8 +80,8 @@ mod DepositVault {
     #[constructor]
     fn constructor(
         ref self: ContractState,
-        role_store_address: ContractAddress,
         data_store_address: ContractAddress,
+        role_store_address: ContractAddress,
     ) {
         self.data_store.write(IDataStoreDispatcher { contract_address: data_store_address });
         self.role_store.write(IRoleStoreDispatcher { contract_address: role_store_address });

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -4,7 +4,7 @@
 //                                  IMPORTS
 // *************************************************************************
 // Core lib imports.
-use integer::u256_from_felt252;
+use integer::{u128_from_felt252, u256_from_felt252};
 use result::ResultTrait;
 use starknet::{
     ContractAddress, get_caller_address, Felt252TryIntoContractAddress, contract_address_const,
@@ -61,6 +61,17 @@ fn given_normal_conditions_when_transfer_out_then_works() {
 }
 
 #[test]
+#[should_panic(expected: ('u256_sub Overflow',))]
+fn given_not_enough_token_when_transfer_out_then_fails() {
+    let (_, receiver_address, _, data_store, deposit_vault, erc20) = setup();
+
+    let amount_to_transfer: u128 = u128_from_felt252(INITIAL_TOKENS_MINTED + 1);
+    deposit_vault.transfer_out(erc20.contract_address, receiver_address, amount_to_transfer);
+
+    teardown(data_store, deposit_vault);
+}
+
+#[test]
 #[should_panic(expected: ('unauthorized_access',))]
 fn given_caller_has_no_controller_role_when_transfer_out_then_fails() {
     let (caller_address, receiver_address, _, data_store, deposit_vault, erc20) = setup();
@@ -88,7 +99,6 @@ fn given_normal_conditions_when_record_transfer_in_then_works() {
 // *********************************************************************************************
 // *                                      SETUP                                                *
 // *********************************************************************************************
-
 /// Utility function to setup the test environment.
 ///
 /// Complete statement to retrieve everything:

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -16,18 +16,42 @@ use snforge_std::{declare, start_prank, stop_prank, ContractClassTrait};
 
 
 // Local imports.
-use satoru::deposit::deposit_vault::{IDepositVaultDispatcher, IDepositVaultDispatcherTrait};
 use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
+use satoru::deposit::deposit_vault::{IDepositVaultDispatcher, IDepositVaultDispatcherTrait};
 use satoru::role::role_store::{IRoleStoreDispatcher, IRoleStoreDispatcherTrait};
 use satoru::role::role;
 use satoru::tests_lib;
+use satoru::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 
+// let (caller_address, deposit_vault, role_store, data_store) = setup();
+
+// *************************************************************************
+//                          UNIT TESTS
+// *************************************************************************
 #[test]
-fn initialize_deposit_vault_test() {
-    let (caller_address, deposit_vault, role_store, data_store) = setup();
-    tests_lib::teardown(data_store.contract_address);
+#[should_panic(expected: ('already_initialized',))]
+fn given_already_intialized_when_initialize_then_fails() {
+    let (_, deposit_vault, role_store, data_store) = setup();
+    deposit_vault.initialize(data_store.contract_address, role_store.contract_address);
+    teardown(data_store, deposit_vault);
 }
 
+#[test]
+fn given_normal_conditions_when_record_transfer_in_then_works() {
+    let (_, deposit_vault, _, data_store) = setup();
+
+    let token: ContractAddress = 'MyToken'.try_into().unwrap();
+    let recorded_amount: u128 = deposit_vault.record_transfer_in(token);
+
+    assert(recorded_amount == 0, 'should be 0');
+
+    teardown(data_store, deposit_vault);
+}
+
+
+// *************************************************************************
+//                          SETUP FUNCTIONS
+// *************************************************************************
 
 /// Utility function to setup the test environment.
 ///
@@ -38,24 +62,17 @@ fn initialize_deposit_vault_test() {
 /// * `IRoleStoreDispatcher` - The role store dispatcher.
 /// * `IDataStoreDispatcher` - The data store dispatcher.
 fn setup() -> (
-    ContractAddress,
-    IDepositVaultDispatcher,
-    IRoleStoreDispatcher,
-    IDataStoreDispatcher,
+    ContractAddress, IDepositVaultDispatcher, IRoleStoreDispatcher, IDataStoreDispatcher,
 ) {
-    // Setup the contracts.
     let (caller_address, role_store, data_store) = tests_lib::setup();
 
     let deposit_vault_address = deploy_deposit_vault(
         data_store.contract_address, role_store.contract_address
     );
-    let deposit_vault = IDepositVaultDispatcher {
-        contract_address: deposit_vault_address
-    };
+    let deposit_vault = IDepositVaultDispatcher { contract_address: deposit_vault_address };
 
-    // Grant roles and prank the caller address.
     start_prank(deposit_vault.contract_address, caller_address);
-    // Return the caller address and the contract interfaces.
+
     (caller_address, deposit_vault, role_store, data_store)
 }
 
@@ -73,4 +90,13 @@ fn deploy_deposit_vault(
 ) -> ContractAddress {
     let contract = declare('DepositVault');
     contract.deploy(@array![data_store_address.into(), role_store_address.into()]).unwrap()
+}
+
+
+// *********************************************************************************************
+// *                              TEARDOWN                                                     *
+// *********************************************************************************************
+fn teardown(data_store: IDataStoreDispatcher, deposit_vault: IDepositVaultDispatcher) {
+    tests_lib::teardown(data_store.contract_address);
+    stop_prank(deposit_vault.contract_address);
 }

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -3,17 +3,15 @@
 // *************************************************************************
 //                                  IMPORTS
 // *************************************************************************
-
 // Core lib imports.
-
+use integer::u256_from_felt252;
 use result::ResultTrait;
-use traits::{TryInto, Into};
 use starknet::{
     ContractAddress, get_caller_address, Felt252TryIntoContractAddress, contract_address_const,
     ClassHash,
 };
 use snforge_std::{declare, start_prank, stop_prank, ContractClassTrait};
-
+use traits::{TryInto, Into};
 
 // Local imports.
 use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
@@ -23,60 +21,124 @@ use satoru::role::role;
 use satoru::tests_lib;
 use satoru::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 
-// let (caller_address, deposit_vault, role_store, data_store) = setup();
+// *********************************************************************************************
+// *                                     TEST CONSTANTS                                        *
+// *********************************************************************************************
+/// Initial amount of ERC20 tokens minted to the deposit vault
+const INITIAL_TOKENS_MINTED: felt252 = 1000;
 
-// *************************************************************************
-//                          UNIT TESTS
-// *************************************************************************
+// *********************************************************************************************
+// *                                      TEST LOGIC                                           *
+// *********************************************************************************************
 #[test]
 #[should_panic(expected: ('already_initialized',))]
 fn given_already_intialized_when_initialize_then_fails() {
-    let (_, deposit_vault, role_store, data_store) = setup();
+    let (_, _, role_store, data_store, deposit_vault, _) = setup();
     deposit_vault.initialize(data_store.contract_address, role_store.contract_address);
     teardown(data_store, deposit_vault);
 }
 
 #[test]
-fn given_normal_conditions_when_record_transfer_in_then_works() {
-    let (_, deposit_vault, _, data_store) = setup();
+fn given_normal_conditions_when_transfer_out_then_works() {
+    let (_, receiver_address, _, data_store, deposit_vault, erc20) = setup();
 
-    let token: ContractAddress = 'MyToken'.try_into().unwrap();
-    let recorded_amount: u128 = deposit_vault.record_transfer_in(token);
+    let amount_to_transfer: u128 = 100;
+    deposit_vault.transfer_out(erc20.contract_address, receiver_address, amount_to_transfer);
 
-    assert(recorded_amount == 0, 'should be 0');
+    // check that the contract balance reduces
+    let contract_balance = erc20.balance_of(deposit_vault.contract_address);
+    let expected_balance: u256 = u256_from_felt252(
+        INITIAL_TOKENS_MINTED - amount_to_transfer.into()
+    );
+    assert(contract_balance == expected_balance, 'transfer_out failed');
+
+    // check that the balance of the receiver increases 
+    let receiver_balance = erc20.balance_of(receiver_address);
+    let expected_balance: u256 = amount_to_transfer.into();
+    assert(receiver_balance == expected_balance, 'transfer_out failed');
 
     teardown(data_store, deposit_vault);
 }
 
+#[test]
+#[should_panic(expected: ('unauthorized_access',))]
+fn given_caller_has_no_controller_role_when_transfer_out_then_fails() {
+    let (caller_address, receiver_address, _, data_store, deposit_vault, erc20) = setup();
+    stop_prank(deposit_vault.contract_address);
+    start_prank(deposit_vault.contract_address, receiver_address);
+    deposit_vault.transfer_out(erc20.contract_address, caller_address, 100_u128);
+    teardown(data_store, deposit_vault);
+}
 
-// *************************************************************************
-//                          SETUP FUNCTIONS
-// *************************************************************************
+#[test]
+#[should_panic(expected: ('self_transfer_not_supported',))]
+fn given_receiver_is_contract_when_transfer_out_then_fails() {
+    let (caller_address, receiver_address, _, data_store, deposit_vault, erc20) = setup();
+    deposit_vault.transfer_out(erc20.contract_address, deposit_vault.contract_address, 100_u128);
+    teardown(data_store, deposit_vault);
+}
+
+/// TODO: implement the tests when record_transfer_in is implemented
+#[test]
+#[should_panic(expected: ('NOT IMPLEMENTED YET',))]
+fn given_normal_conditions_when_record_transfer_in_then_works() {
+    assert(true == false, 'NOT IMPLEMENTED YET')
+}
+
+// *********************************************************************************************
+// *                                      SETUP                                                *
+// *********************************************************************************************
 
 /// Utility function to setup the test environment.
+///
+/// Complete statement to retrieve everything:
+///     let (
+///         caller_address, receiver_address,
+///         role_store, data_store,
+///         deposit_vault,
+///         erc20
+///     ) = setup();
 ///
 /// # Returns
 ///
 /// * `ContractAddress` - The address of the caller.
-/// * `IDepositVaultDispatcher` - The deposit vault dispatcher.
+/// * `ContractAddress` - The address of the receiver.
 /// * `IRoleStoreDispatcher` - The role store dispatcher.
 /// * `IDataStoreDispatcher` - The data store dispatcher.
+/// * `IDepositVaultDispatcher` - The deposit vault dispatcher.
+/// * `IERC20Dispatcher` - The ERC20 token dispatcher.
 fn setup() -> (
-    ContractAddress, IDepositVaultDispatcher, IRoleStoreDispatcher, IDataStoreDispatcher,
+    ContractAddress,
+    ContractAddress,
+    IRoleStoreDispatcher,
+    IDataStoreDispatcher,
+    IDepositVaultDispatcher,
+    IERC20Dispatcher
 ) {
+    // get caller_address, role store and data_store from tests_lib::setup()
     let (caller_address, role_store, data_store) = tests_lib::setup();
 
+    // get receiver_address
+    let receiver_address: ContractAddress = 0x202.try_into().unwrap();
+
+    // deploy deposit vault
     let deposit_vault_address = deploy_deposit_vault(
         data_store.contract_address, role_store.contract_address
     );
     let deposit_vault = IDepositVaultDispatcher { contract_address: deposit_vault_address };
 
+    // deploy erc20 token
+    let erc20_contract_address = deploy_erc20_token(deposit_vault_address);
+    let erc20 = IERC20Dispatcher { contract_address: erc20_contract_address };
+
+    // start prank and give controller role to caller_address
     start_prank(deposit_vault.contract_address, caller_address);
 
-    (caller_address, deposit_vault, role_store, data_store)
+    return (caller_address, receiver_address, role_store, data_store, deposit_vault, erc20);
 }
 
 /// Utility function to deploy a deposit vault.
+///
 /// # Arguments
 ///
 /// * `data_store_address` - The address of the data store contract.
@@ -88,13 +150,31 @@ fn setup() -> (
 fn deploy_deposit_vault(
     data_store_address: ContractAddress, role_store_address: ContractAddress
 ) -> ContractAddress {
-    let contract = declare('DepositVault');
-    contract.deploy(@array![data_store_address.into(), role_store_address.into()]).unwrap()
+    let deposit_vault_contract = declare('DepositVault');
+    let constructor_calldata2 = array![data_store_address.into(), role_store_address.into()];
+    deposit_vault_contract.deploy(@constructor_calldata2).unwrap()
 }
 
+/// Utility function to deploy an ERC20 token.
+/// When deployed, 1000 tokens are minted to the deposit vault address.
+///
+/// # Arguments
+///
+/// * `deposit_vault_address` - The address of the deposit vault address.
+///
+/// # Returns
+///
+/// * `ContractAddress` - The address of the ERC20 token.
+fn deploy_erc20_token(deposit_vault_address: ContractAddress) -> ContractAddress {
+    let erc20_contract = declare('ERC20');
+    let constructor_calldata3 = array![
+        'satoru', 'STU', INITIAL_TOKENS_MINTED, 0, deposit_vault_address.into()
+    ];
+    erc20_contract.deploy(@constructor_calldata3).unwrap()
+}
 
 // *********************************************************************************************
-// *                              TEARDOWN                                                     *
+// *                                     TEARDOWN                                              *
 // *********************************************************************************************
 fn teardown(data_store: IDataStoreDispatcher, deposit_vault: IDepositVaultDispatcher) {
     tests_lib::teardown(data_store.contract_address);

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -20,131 +20,57 @@ use satoru::deposit::deposit_vault::{IDepositVaultDispatcher, IDepositVaultDispa
 use satoru::data::data_store::{IDataStoreDispatcher, IDataStoreDispatcherTrait};
 use satoru::role::role_store::{IRoleStoreDispatcher, IRoleStoreDispatcherTrait};
 use satoru::role::role;
+use satoru::tests_lib;
 
-/// TODO: Implement actual test and change the name of this function.
-// #[test]
-// fn init_deposit_vault_test() {
-//     // *********************************************************************************************
-//     // *                              SETUP                                                        *
-//     // *********************************************************************************************
+#[test]
+fn initialize_deposit_vault_test() {
+    let (caller_address, deposit_vault, role_store, data_store) = setup();
+    tests_lib::teardown(data_store.contract_address);
+}
 
-//     let (caller_address, deposit_vault, role_store, data_store) = setup();
-//     // *********************************************************************************************
-//     // *                              TEST LOGIC                                                   *
-//     // *********************************************************************************************
-
-//     // Empty test for now.
-
-//     // *********************************************************************************************
-//     // *                              TEARDOWN                                                     *
-//     // *********************************************************************************************
-//     teardown(data_store, deposit_vault);
-// }
 
 /// Utility function to setup the test environment.
+///
+/// # Returns
+///
+/// * `ContractAddress` - The address of the caller.
+/// * `IDepositVaultDispatcher` - The deposit vault dispatcher.
+/// * `IRoleStoreDispatcher` - The role store dispatcher.
+/// * `IDataStoreDispatcher` - The data store dispatcher.
 fn setup() -> (
-    // This caller address will be used with `start_prank` cheatcode to mock the caller address.,
-    ContractAddress, // Interface to interact with the `DepositVault` contract.
-    IDepositVaultDispatcher, // Interface to interact with the `RoleStore` contract.
-    IRoleStoreDispatcher, // Interface to interact with the `DataStore` contract.
+    ContractAddress,
+    IDepositVaultDispatcher,
+    IRoleStoreDispatcher,
     IDataStoreDispatcher,
 ) {
     // Setup the contracts.
-    let (caller_address, deposit_vault, role_store, data_store) = setup_contracts();
+    let (caller_address, role_store, data_store) = tests_lib::setup();
+
+    let deposit_vault_address = deploy_deposit_vault(
+        data_store.contract_address, role_store.contract_address
+    );
+    let deposit_vault = IDepositVaultDispatcher {
+        contract_address: deposit_vault_address
+    };
+
     // Grant roles and prank the caller address.
-    grant_roles_and_prank(caller_address, deposit_vault, role_store, data_store);
+    start_prank(deposit_vault.contract_address, caller_address);
     // Return the caller address and the contract interfaces.
     (caller_address, deposit_vault, role_store, data_store)
 }
 
-// Utility function to grant roles and prank the caller address.
-/// Grants roles and pranks the caller address.
-///
+/// Utility function to deploy a deposit vault.
 /// # Arguments
 ///
-/// * `caller_address` - The address of the caller.
-/// * `deposit_vault` - The interface to interact with the `DepositVault` contract.
-/// * `role_store` - The interface to interact with the `RoleStore` contract.
-/// * `data_store` - The interface to interact with the `DataStore` contract.
-fn grant_roles_and_prank(
-    caller_address: ContractAddress,
-    deposit_vault: IDepositVaultDispatcher,
-    role_store: IRoleStoreDispatcher,
-    data_store: IDataStoreDispatcher,
-) {
-    start_prank(role_store.contract_address, caller_address);
-
-    // Grant the caller the `CONTROLLER` role.
-    role_store.grant_role(caller_address, role::CONTROLLER);
-
-    // Prank the caller address for calls to `DataStore` contract.
-    // We need this so that the caller has the CONTROLLER role.
-    start_prank(data_store.contract_address, caller_address);
-
-    // Start pranking the `DepositVault` contract. This is necessary to mock the behavior of the contract
-    // for testing purposes.
-    start_prank(deposit_vault.contract_address, caller_address);
-}
-
-/// Utility function to teardown the test environment.
-fn teardown(data_store: IDataStoreDispatcher, deposit_vault: IDepositVaultDispatcher) {
-    stop_prank(data_store.contract_address);
-    stop_prank(deposit_vault.contract_address);
-}
-
-/// Setup required contracts.
-fn setup_contracts() -> (
-    // This caller address will be used with `start_prank` cheatcode to mock the caller address.,
-    ContractAddress, // Interface to interact with the `DepositVault` contract.
-    IDepositVaultDispatcher, // Interface to interact with the `RoleStore` contract.
-    IRoleStoreDispatcher, // Interface to interact with the `DataStore` contract.
-    IDataStoreDispatcher,
-) {
-    let caller_address = 0x101.try_into().unwrap();
-    // Deploy the role store contract.
-    let role_store_address = deploy_role_store();
-
-    // Create a role store dispatcher.
-    let role_store = IRoleStoreDispatcher { contract_address: role_store_address };
-
-    // Deploy the contract.
-    let data_store_address = deploy_data_store(role_store_address);
-    // Create a safe dispatcher to interact with the contract.
-    let data_store = IDataStoreDispatcher { contract_address: data_store_address };
-
-    // Deploy the `DepositVault` contract.
-    let deposit_vault_address = deploy_deposit_vault(role_store_address, data_store_address);
-    // Create a safe dispatcher to interact with the contract.
-    let deposit_vault = IDepositVaultDispatcher { contract_address: deposit_vault_address };
-
-    // Return the caller address and the contract interfaces.
-    (caller_address, deposit_vault, role_store, data_store)
-}
-
-
-/// Utility function to deploy a `DepositVault` contract and return its address.
+/// * `data_store_address` - The address of the data store contract.
+/// * `role_store_address` - The address of the role store contract.
+///
+/// # Returns
+///
+/// * `ContractAddress` - The address of the deposit vault.
 fn deploy_deposit_vault(
-    role_store_address: ContractAddress, data_store_address: ContractAddress,
+    data_store_address: ContractAddress, role_store_address: ContractAddress
 ) -> ContractAddress {
     let contract = declare('DepositVault');
-    let mut constructor_calldata = array![];
-    constructor_calldata.append(role_store_address.into());
-    contract.deploy(@constructor_calldata).unwrap()
-}
-
-
-/// Utility function to deploy a data store contract and return its address.
-fn deploy_data_store(role_store_address: ContractAddress) -> ContractAddress {
-    let contract = declare('DataStore');
-    let mut constructor_calldata = array![];
-    constructor_calldata.append(role_store_address.into());
-    contract.deploy(@constructor_calldata).unwrap()
-}
-
-/// Utility function to deploy a data store contract and return its address.
-/// Copied from `tests/role/test_role_store.rs`.
-/// TODO: Find a way to share this code.
-fn deploy_role_store() -> ContractAddress {
-    let contract = declare('RoleStore');
-    contract.deploy(@ArrayTrait::new()).unwrap()
+    contract.deploy(@array![data_store_address.into(), role_store_address.into()]).unwrap()
 }


### PR DESCRIPTION
Please add the labels corresponding to the type of changes your PR introduces:

- Testing

## What is the current behavior?

Resolves: Issue [#477 ](https://github.com/keep-starknet-strange/satoru/issues/477)

## What is the new behavior?

- Swapped the order of constructor parameters for `DepositVault` so it's the same order as `StrictBank` & follows the `initialize()` function order
- Added unit tests into `test/deposit/deposit_vault.cairo`

## Does this introduce a breaking change?

Should be a **no**, but there is that swap of parameters order in the `DepositVault` constructor. I can revert it if it's dangerous/out of scope!

## Other information

1. I have no implemented tests for `record_transfer_in()` as the function is not implemented yet. Happy to do it in this PR if you have more informations! 😁

2. I've this test that should fail:
```rust
#[test]
#[should_panic(expected: ('u256_sub Overflow',))]
fn given_not_enough_token_when_transfer_out_then_fails() {
```
For when a `transfer_out` happens and there's not enough token in the `DepositVault` but I'm really not sure if this is the "right" expected message for the `should_panic` line.
Maybe we can handle that condition in `src/token/token_utils.cairo -> transfer()` to have a relevant error but not sure if that check/computation is what we want.

Thanks!
