### PR TITLE
test: Added tests for record_transfer_in

### DIFF
--- a/src/bank/strict_bank.cairo
+++ b/src/bank/strict_bank.cairo
@@ -7,6 +7,7 @@
 // Core lib imports.
 use traits::{Into, TryInto};
 use starknet::{ContractAddress, get_contract_address};
+use integer::u128_sub;
 
 // *************************************************************************
 //                  Interface of the `StrictBank` contract.
@@ -172,7 +173,11 @@ mod StrictBank {
                 .try_into()
                 .unwrap();
             self.token_balances.write(token, next_balance);
-            next_balance - prev_balance
+            if next_balance >= prev_balance {
+                next_balance - prev_balance
+            } else {
+                0
+            }
         }
     }
 }

--- a/src/bank/strict_bank.cairo
+++ b/src/bank/strict_bank.cairo
@@ -7,7 +7,6 @@
 // Core lib imports.
 use traits::{Into, TryInto};
 use starknet::{ContractAddress, get_contract_address};
-use integer::u128_sub;
 
 // *************************************************************************
 //                  Interface of the `StrictBank` contract.

--- a/src/bank/strict_bank.cairo
+++ b/src/bank/strict_bank.cairo
@@ -172,11 +172,7 @@ mod StrictBank {
                 .try_into()
                 .unwrap();
             self.token_balances.write(token, next_balance);
-            if next_balance >= prev_balance {
-                next_balance - prev_balance
-            } else {
-                0
-            }
+            next_balance - prev_balance
         }
     }
 }

--- a/src/deposit/deposit_vault.cairo
+++ b/src/deposit/deposit_vault.cairo
@@ -114,8 +114,8 @@ mod DepositVault {
         }
 
         fn record_transfer_in(ref self: ContractState, token: ContractAddress) -> u128 {
-            // TODO
-            0
+            let mut state: StrictBank::ContractState = StrictBank::unsafe_new_contract_state();
+            IStrictBank::record_transfer_in(ref state, token)
         }
     }
 }

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -108,12 +108,12 @@ fn given_more_balance_when_2nd_record_transfer_in_then_works() {
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
     assert(tokens_received == initial_balance, 'should be initial balance');
 
-    let tokens_transfered: u128 = 250;
-    let mock_balance_with_more_tokens: u256 = (initial_balance + tokens_transfered).into();
+    let tokens_transfered_in: u128 = 250;
+    let mock_balance_with_more_tokens: u256 = (initial_balance + tokens_transfered_in).into();
     start_mock_call(erc20.contract_address, 'balance_of', mock_balance_with_more_tokens);
 
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
-    assert(tokens_received == tokens_transfered, 'incorrect received amount');
+    assert(tokens_received == tokens_transfered_in, 'incorrect received amount');
 
     teardown(data_store, deposit_vault);
 }
@@ -126,8 +126,9 @@ fn given_less_balance_when_2nd_record_transfer_in_then_works() {
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
     assert(tokens_received == initial_balance, 'should be initial balance');
 
-    let amount_to_throw: u128 = 250;
-    deposit_vault.transfer_out(erc20.contract_address, receiver_address, amount_to_throw);
+    let tokens_transfered_out: u128 = 250;
+    let mock_balance_with_less_tokens: u256 = (initial_balance - tokens_transfered_out).into();
+    start_mock_call(erc20.contract_address, 'balance_of', mock_balance_with_less_tokens);
 
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
     assert(tokens_received == 0, 'should be zero');

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -131,7 +131,7 @@ fn given_less_balance_when_2nd_record_transfer_in_then_fails() {
     let mock_balance_with_less_tokens: u256 = (initial_balance - tokens_transfered_out).into();
     start_mock_call(erc20.contract_address, 'balance_of', mock_balance_with_less_tokens);
 
-    let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
+    deposit_vault.record_transfer_in(erc20.contract_address);
 
     teardown(data_store, deposit_vault);
 }

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -119,7 +119,8 @@ fn given_more_balance_when_2nd_record_transfer_in_then_works() {
 }
 
 #[test]
-fn given_less_balance_when_2nd_record_transfer_in_then_works() {
+#[should_panic(expected: ('u128_sub Overflow',))]
+fn given_less_balance_when_2nd_record_transfer_in_then_fails() {
     let (_, receiver_address, _, data_store, deposit_vault, erc20) = setup();
 
     let initial_balance: u128 = u128_from_felt252(INITIAL_TOKENS_MINTED);
@@ -131,7 +132,6 @@ fn given_less_balance_when_2nd_record_transfer_in_then_works() {
     start_mock_call(erc20.contract_address, 'balance_of', mock_balance_with_less_tokens);
 
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
-    assert(tokens_received == 0, 'should be zero');
 
     teardown(data_store, deposit_vault);
 }

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -89,11 +89,43 @@ fn given_receiver_is_contract_when_transfer_out_then_fails() {
     teardown(data_store, deposit_vault);
 }
 
-/// TODO: implement the tests when record_transfer_in is implemented
 #[test]
-#[should_panic(expected: ('NOT IMPLEMENTED YET',))]
 fn given_normal_conditions_when_record_transfer_in_then_works() {
-    assert(true == false, 'NOT IMPLEMENTED YET')
+    let (_, _, _, data_store, deposit_vault, erc20) = setup();
+
+    let initial_balance: u128 = u128_from_felt252(INITIAL_TOKENS_MINTED);
+    let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
+    assert(tokens_received == initial_balance, 'should be initial balance');
+
+    teardown(data_store, deposit_vault);
+}
+
+#[test]
+fn given_less_balance_when_record_transfer_in_then_works() {
+    let (_, receiver_address, _, data_store, deposit_vault, erc20) = setup();
+
+    let initial_balance: u128 = u128_from_felt252(INITIAL_TOKENS_MINTED);
+    let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
+    assert(tokens_received == initial_balance, 'should be initial balance');
+
+    let amount_to_throw: u128 = 250;
+    deposit_vault.transfer_out(erc20.contract_address, receiver_address, amount_to_throw);
+
+    let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
+    assert(tokens_received == 0, 'should be zero');
+
+    teardown(data_store, deposit_vault);
+}
+
+#[test]
+#[should_panic(expected: ('unauthorized_access',))]
+fn given_caller_is_not_controller_when_record_transfer_in_then_fails() {
+    let (caller_address, _, role_store, data_store, deposit_vault, erc20) = setup();
+
+    role_store.revoke_role(caller_address, role::CONTROLLER);
+    deposit_vault.record_transfer_in(erc20.contract_address);
+
+    teardown(data_store, deposit_vault);
 }
 
 // *********************************************************************************************

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -102,7 +102,7 @@ fn given_normal_conditions_when_record_transfer_in_then_works() {
 
 #[test]
 fn given_more_balance_when_2nd_record_transfer_in_then_works() {
-    let (_, receiver_address, _, data_store, deposit_vault, erc20) = setup();
+    let (_, _, _, data_store, deposit_vault, erc20) = setup();
 
     let initial_balance: u128 = u128_from_felt252(INITIAL_TOKENS_MINTED);
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
@@ -121,7 +121,7 @@ fn given_more_balance_when_2nd_record_transfer_in_then_works() {
 #[test]
 #[should_panic(expected: ('u128_sub Overflow',))]
 fn given_less_balance_when_2nd_record_transfer_in_then_fails() {
-    let (_, receiver_address, _, data_store, deposit_vault, erc20) = setup();
+    let (_, _, _, data_store, deposit_vault, erc20) = setup();
 
     let initial_balance: u128 = u128_from_felt252(INITIAL_TOKENS_MINTED);
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);

--- a/tests/deposit/test_deposit_vault.cairo
+++ b/tests/deposit/test_deposit_vault.cairo
@@ -113,7 +113,7 @@ fn given_more_balance_when_2nd_record_transfer_in_then_works() {
     start_mock_call(erc20.contract_address, 'balance_of', mock_balance_with_more_tokens);
 
     let tokens_received: u128 = deposit_vault.record_transfer_in(erc20.contract_address);
-    assert(tokens_received == tokens_transfered, 'should be zero');
+    assert(tokens_received == tokens_transfered, 'incorrect received amount');
 
     teardown(data_store, deposit_vault);
 }


### PR DESCRIPTION
# Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Feature
- Testing

## What is the current behavior?

Resolves: #497 

## What is the new behavior?

- Added implementation of `deposit_vault::record_transfer_in`
- Added related unit tests

## Does this introduce a breaking change?

No

## Other information

The function `StrictBank::record_transfer_in_internal` used to overflow & panic when the new balance was lower than the previous one recorded. A check has been added, it now returns zero if its is lower.
Let me know if it should panic as before instead!