### PR TITLE
fix: `u32_sub Overflow` if the index isn't found in datastore

### DIFF
--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -863,7 +863,7 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::MARKET_KEEPER);
             let offsetted_index: usize = self.market_indexes.read(key);
             let mut markets = self.markets.read();
-            assert(offsetted_index <= markets.len(), MarketError::MARKET_NOT_FOUND);
+            assert(offsetted_index != 0 && offsetted_index <= markets.len(), MarketError::MARKET_NOT_FOUND);
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last market in the list.
@@ -984,7 +984,7 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.order_indexes.read(key);
             let mut orders = self.orders.read();
-            assert(offsetted_index <= orders.len(), OrderError::ORDER_NOT_FOUND);
+            assert(offsetted_index != 0 && offsetted_index <= orders.len(), OrderError::ORDER_NOT_FOUND);
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last order in the list.
@@ -1115,7 +1115,7 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.position_indexes.read(key);
             let mut positions = self.positions.read();
-            assert(offsetted_index <= positions.len(), PositionError::POSITION_NOT_FOUND);
+            assert(offsetted_index != 0 && offsetted_index <= positions.len(), PositionError::POSITION_NOT_FOUND);
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last position in the list.
@@ -1248,7 +1248,7 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.withdrawal_indexes.read(key);
             let mut withdrawals = self.withdrawals.read();
-            assert(offsetted_index <= withdrawals.len(), WithdrawalError::NOT_FOUND);
+            assert(offsetted_index != 0 && offsetted_index <= withdrawals.len(), WithdrawalError::NOT_FOUND);
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last withdrawal in the list.
@@ -1374,7 +1374,7 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.deposit_indexes.read(key);
             let mut deposits = self.deposits.read();
-            assert(offsetted_index <= deposits.len(), DepositError::DEPOSIT_NOT_FOUND);
+            assert(offsetted_index != 0 && offsetted_index <= deposits.len(), DepositError::DEPOSIT_NOT_FOUND);
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last deposit in the list.

--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -863,7 +863,10 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::MARKET_KEEPER);
             let offsetted_index: usize = self.market_indexes.read(key);
             let mut markets = self.markets.read();
-            assert(offsetted_index != 0 && offsetted_index <= markets.len(), MarketError::MARKET_NOT_FOUND);
+            assert(
+                offsetted_index != 0 && offsetted_index <= markets.len(),
+                MarketError::MARKET_NOT_FOUND
+            );
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last market in the list.
@@ -984,7 +987,9 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.order_indexes.read(key);
             let mut orders = self.orders.read();
-            assert(offsetted_index != 0 && offsetted_index <= orders.len(), OrderError::ORDER_NOT_FOUND);
+            assert(
+                offsetted_index != 0 && offsetted_index <= orders.len(), OrderError::ORDER_NOT_FOUND
+            );
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last order in the list.
@@ -1115,7 +1120,10 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.position_indexes.read(key);
             let mut positions = self.positions.read();
-            assert(offsetted_index != 0 && offsetted_index <= positions.len(), PositionError::POSITION_NOT_FOUND);
+            assert(
+                offsetted_index != 0 && offsetted_index <= positions.len(),
+                PositionError::POSITION_NOT_FOUND
+            );
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last position in the list.
@@ -1248,7 +1256,10 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.withdrawal_indexes.read(key);
             let mut withdrawals = self.withdrawals.read();
-            assert(offsetted_index != 0 && offsetted_index <= withdrawals.len(), WithdrawalError::NOT_FOUND);
+            assert(
+                offsetted_index != 0 && offsetted_index <= withdrawals.len(),
+                WithdrawalError::NOT_FOUND
+            );
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last withdrawal in the list.
@@ -1374,7 +1385,10 @@ mod DataStore {
             self.role_store.read().assert_only_role(get_caller_address(), role::CONTROLLER);
             let offsetted_index: usize = self.deposit_indexes.read(key);
             let mut deposits = self.deposits.read();
-            assert(offsetted_index != 0 && offsetted_index <= deposits.len(), DepositError::DEPOSIT_NOT_FOUND);
+            assert(
+                offsetted_index != 0 && offsetted_index <= deposits.len(),
+                DepositError::DEPOSIT_NOT_FOUND
+            );
 
             let index = offsetted_index - 1;
             // Replace the value at `index` by the last deposit in the list.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If the index isn't found in `remove_*` function, then `offsetted_index == 0` and panic with `u32_sub Overflow` in the instruction `let index = offsetted_index - 1;`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
If the index isn't found in `remove_*` function, then `offsetted_index == 0` and panic with `MarketError::MARKET_NOT_FOUND`.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
