### PR TITLE
Improve test widthdrawal handler

### DIFF
--- a/src/exchange/withdrawal_handler.cairo
+++ b/src/exchange/withdrawal_handler.cairo
@@ -174,7 +174,7 @@ mod WithdrawalHandler {
 
             global_reentrancy_guard::non_reentrant_before(data_store); // Initiates re-entrancy
 
-            let starting_gas = starknet_utils::sn_gasleft(array![100]); // Returns 100 for now,
+            let starting_gas = starknet_utils::sn_gasleft(array![200]); // Returns 200 for now,
             let withdrawal = data_store.get_withdrawal(key);
 
             feature_utils::validate_feature(

--- a/src/market/market_utils.cairo
+++ b/src/market/market_utils.cairo
@@ -2568,9 +2568,11 @@ fn validate_enabled_market_check(
 fn validate_enabled_market(data_store: IDataStoreDispatcher, market: Market) {
     assert(market.market_token != 0.try_into().unwrap(), MarketError::EMPTY_MARKET);
 
-    let is_market_disabled: bool = data_store
-        .get_bool(keys::is_market_disabled_key(market.market_token))
-        .unwrap();
+    let is_market_disabled: bool =
+        match data_store.get_bool(keys::is_market_disabled_key(market.market_token)) {
+        Option::Some(value) => value,
+        Option::None => false
+    };
 
     if (is_market_disabled) {
         MarketError::DISABLED_MARKET(is_market_disabled);

--- a/src/withdrawal/withdrawal_utils.cairo
+++ b/src/withdrawal/withdrawal_utils.cairo
@@ -134,11 +134,7 @@ fn create_withdrawal(
     account_utils::validate_receiver(params.receiver);
 
     let market_token_amount = withdrawal_vault.record_transfer_in(params.market);
-
-    if market_token_amount.is_zero() {
-        WithdrawalError::EMPTY_WITHDRAWAL_AMOUNT;
-    }
-
+    assert(market_token_amount.is_non_zero(), WithdrawalError::EMPTY_WITHDRAWAL_AMOUNT);
     params.execution_fee = fee_token_amount.into();
 
     market_utils::validate_enabled_market_check(data_store, params.market);

--- a/src/withdrawal/withdrawal_utils.cairo
+++ b/src/withdrawal/withdrawal_utils.cairo
@@ -183,7 +183,9 @@ fn create_withdrawal(
     gas_utils::validate_execution_fee(data_store, estimated_gas_limit, params.execution_fee);
 
     let key = nonce_utils::get_next_key(data_store);
-
+    // assign generated key to withdrawal
+    withdrawal.key = key;
+    // store withdrawal
     data_store.set_withdrawal(key, withdrawal);
 
     event_emitter.emit_withdrawal_created(key, withdrawal);

--- a/tests/exchange/test_withdrawal_handler.cairo
+++ b/tests/exchange/test_withdrawal_handler.cairo
@@ -52,8 +52,7 @@ fn given_normal_conditions_when_create_withdrawal_then_works() {
 
     //check withdrawal datas created
     let withdrawal = data_store.get_withdrawal(key);
-    //withdrawal is actually created with key  = 0
-    assert(withdrawal.key == 0, 'Invalid withdrawal key');
+    assert(withdrawal.key == key, 'Invalid withdrawal key');
     assert(withdrawal.account == account, 'Invalid withdrawal account');
 }
 

--- a/tests/exchange/test_withdrawal_handler.cairo
+++ b/tests/exchange/test_withdrawal_handler.cairo
@@ -56,7 +56,7 @@ fn given_normal_conditions_when_create_withdrawal_then_works() {
 // The test expects the call to panic with error empty withdrawal amount
 #[test]
 #[should_panic(expected: ('empty withdrawal amount',))]
-fn given_normal_conditions_when_create_withdrawal_then_works() {
+fn given_market_token_amount_equal_zero_when_create_withdrawal_then_fails() {
     let (caller_address, data_store, event_emitter, withdrawal_handler, withdrawal_vault_address) =
         setup();
     start_prank(withdrawal_handler.contract_address, caller_address);

--- a/tests/exchange/test_withdrawal_handler.cairo
+++ b/tests/exchange/test_withdrawal_handler.cairo
@@ -1,7 +1,9 @@
 use starknet::{
     ContractAddress, get_caller_address, Felt252TryIntoContractAddress, contract_address_const
 };
-use snforge_std::{declare, start_prank, stop_prank, ContractClassTrait};
+use snforge_std::{
+    declare, start_prank, stop_prank, start_mock_call, stop_mock_call, ContractClassTrait
+};
 
 use satoru::event::event_emitter::{IEventEmitterDispatcher, IEventEmitterDispatcherTrait};
 use satoru::exchange::withdrawal_handler::{
@@ -22,35 +24,75 @@ use satoru::withdrawal::withdrawal::Withdrawal;
 use satoru::market::market::Market;
 use traits::Default;
 
-// TODO: Add more tests after withdraw_utils implementation done.
+// This tests check withdrawal creation under normal condition
+// It calls withdrawal_handler.create_withdrawal
+// The test expects the call to succeed without error
 #[test]
 fn given_normal_conditions_when_create_withdrawal_then_works() {
-    let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+    let (caller_address, data_store, event_emitter, withdrawal_handler, withdrawal_vault_address) =
+        setup();
     start_prank(withdrawal_handler.contract_address, caller_address);
 
     let account = contract_address_const::<'account'>();
+    let market_token = contract_address_const::<'market_token'>();
+    let params = create_withrawal_params(market_token);
 
     let address_zero = contract_address_const::<0>();
 
-    let key = contract_address_const::<123456789>();
     let mut market = Market {
-        market_token: key,
+        market_token: market_token,
         index_token: address_zero,
         long_token: address_zero,
         short_token: address_zero,
     };
 
-    data_store.set_market(key, 0, market);
-
-    let params = create_withrawal_params(key);
-//withdrawal_handler.create_withdrawal(account, params); TODO fix create_withdrawal
+    data_store.set_market(market_token, 0, market);
+    start_mock_call(withdrawal_vault_address, 'record_transfer_in', 1);
+    withdrawal_handler.create_withdrawal(account, params);
 }
 
+// This tests check withdrawal creation when market_token_amount is 0
+// It calls withdrawal_handler.create_withdrawal
+// The test expects the call to panic with error empty withdrawal amount
+#[test]
+#[should_panic(expected: ('empty withdrawal amount',))]
+fn given_normal_conditions_when_create_withdrawal_then_works() {
+    let (caller_address, data_store, event_emitter, withdrawal_handler, withdrawal_vault_address) =
+        setup();
+    start_prank(withdrawal_handler.contract_address, caller_address);
+
+    let account = contract_address_const::<'account'>();
+    let market_token = contract_address_const::<'market_token'>();
+    let params = create_withrawal_params(market_token);
+
+    withdrawal_handler.create_withdrawal(account, params);
+}
+
+// This tests check withdrawal creation when fee token amount is lower than execution fee
+// It calls withdrawal_handler.create_withdrawal
+// The test expects the call to panic with the error 'insufficient fee token amout'
+#[test]
+#[should_panic(expected: ('insufficient fee token amout', 0, 1))]
+fn given_fee_token_lower_than_execution_fee_conditions_when_create_withdrawal_then_fails() {
+    let (caller_address, data_store, event_emitter, withdrawal_handler, _) = setup();
+    start_prank(withdrawal_handler.contract_address, caller_address);
+
+    let account = contract_address_const::<'account'>();
+    let market_token = contract_address_const::<'market_token'>();
+    let mut params = create_withrawal_params(market_token);
+    params.execution_fee = 1;
+
+    withdrawal_handler.create_withdrawal(account, params);
+}
+
+// This tests check withdrawal creation when caller address doesn't meet controller role
+// It calls withdrawal_handler.create_withdrawal
+// The test expects the call to panic with the error 'unauthorized_access'.
 #[test]
 #[should_panic(expected: ('unauthorized_access',))]
 fn given_caller_not_controller_when_create_withdrawal_then_fails() {
     // Should revert, call from anyone else then controller.
-    let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+    let (caller_address, data_store, event_emitter, withdrawal_handler, _) = setup();
     let caller: ContractAddress = 0x847.try_into().unwrap();
     start_prank(withdrawal_handler.contract_address, caller);
 
@@ -61,9 +103,13 @@ fn given_caller_not_controller_when_create_withdrawal_then_fails() {
     withdrawal_handler.create_withdrawal(caller, params);
 }
 
+// This test checks withdrawal cancellation under normal condition
+// It calls withdrawal_handler.cancel_withdrawal
+// The test expects the call to succeed without error
 #[test]
 fn given_normal_conditions_when_cancel_withdrawal_then_works() {
-    let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+    let (caller_address, data_store, event_emitter, withdrawal_handler, withdrawal_vault_address) =
+        setup();
     start_prank(withdrawal_handler.contract_address, caller_address);
 
     let account = contract_address_const::<'account'>();
@@ -79,16 +125,26 @@ fn given_normal_conditions_when_cancel_withdrawal_then_works() {
     data_store.set_market(key, 0, market);
 
     let params = create_withrawal_params(key);
-//let withdrawal_key = withdrawal_handler.create_withdrawal(account, params); TODO fix create_withdrawal
+    start_mock_call(withdrawal_vault_address, 'record_transfer_in', 1);
 
-// Key cleaning should be done in withdrawal_utils. We only check call here.
-//withdrawal_handler.cancel_withdrawal(withdrawal_key);
+    let withdrawal_key = withdrawal_handler.create_withdrawal(account, params);
+
+    start_mock_call(
+        withdrawal_vault_address,
+        'transfer_out',
+        array![contract_address_const::<'market_token'>().into(), account.into(), '1']
+    );
+    // Key cleaning should be done in withdrawal_utils. We only check call here.
+    withdrawal_handler.cancel_withdrawal(withdrawal_key);
 }
 
+// This tests check withdrawal cancellation when key doesn't exist in store
+// It calls withdrawal_handler.cancel_withdrawal
+// The test expects the call to panic with the error 'get_withdrawal failed'.
 #[test]
 #[should_panic(expected: ('empty withdrawal',))]
 fn given_unexisting_key_when_cancel_withdrawal_then_fails() {
-    let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+    let (caller_address, data_store, event_emitter, withdrawal_handler, _) = setup();
     start_prank(withdrawal_handler.contract_address, caller_address);
 
     let withdrawal_key = 'SAMPLE_WITHDRAW';
@@ -97,6 +153,111 @@ fn given_unexisting_key_when_cancel_withdrawal_then_fails() {
     withdrawal_handler.cancel_withdrawal(withdrawal_key);
 }
 
+// This tests check withdrawal cancellation when account address is 0
+// It calls withdrawal_handler.cancel_withdrawal
+// The test expects the call to panic with the error 'empty withdrawal'.
+#[test]
+#[should_panic(expected: ('empty withdrawal',))]
+fn given_account_address_zero_when_cancel_withdrawal_then_fails() {
+    let mut withdrawal = Withdrawal {
+        key: 0,
+        account: contract_address_const::<0>(),
+        receiver: contract_address_const::<0>(),
+        callback_contract: contract_address_const::<0>(),
+        ui_fee_receiver: contract_address_const::<0>(),
+        market: contract_address_const::<0>(),
+        long_token_swap_path: Default::default(),
+        short_token_swap_path: Default::default(),
+        market_token_amount: 0,
+        min_long_token_amount: 0,
+        min_short_token_amount: 0,
+        updated_at_block: 0,
+        execution_fee: 0,
+        callback_gas_limit: 0,
+    };
+
+    let (caller_address, data_store, event_emitter, withdrawal_handler, withdrawal_vault_address) =
+        setup();
+    start_prank(withdrawal_handler.contract_address, caller_address);
+
+    let account = contract_address_const::<'account'>();
+    let key = contract_address_const::<'market'>();
+    let mut params = create_withrawal_params(key);
+
+    let market = Market {
+        market_token: key,
+        index_token: contract_address_const::<'index_token'>(),
+        long_token: contract_address_const::<'long_token'>(),
+        short_token: contract_address_const::<'short_token'>(),
+    };
+
+    data_store.set_market(key, 0, market);
+
+    start_mock_call(withdrawal_vault_address, 'record_transfer_in', 1);
+
+    let withdrawal_key = withdrawal_handler.create_withdrawal(account, params);
+
+    start_mock_call(data_store.contract_address, 'get_withdrawal', withdrawal);
+
+    // Key cleaning should be done in withdrawal_utils. We only check call here.
+    withdrawal_handler.cancel_withdrawal(withdrawal_key);
+}
+
+
+// This tests check withdrawal cancellation when market token amount is 0
+// It calls withdrawal_handler.cancel_withdrawal
+// The test expects the call to panic with the error 'empty withdrawal'.
+#[test]
+#[should_panic(expected: ('empty withdrawal amount',))]
+fn given_market_token_equals_zero_when_cancel_withdrawal_then_fails() {
+    let mut withdrawal = Withdrawal {
+        key: 0,
+        account: contract_address_const::<'account'>(),
+        receiver: contract_address_const::<0>(),
+        callback_contract: contract_address_const::<0>(),
+        ui_fee_receiver: contract_address_const::<0>(),
+        market: contract_address_const::<0>(),
+        long_token_swap_path: Default::default(),
+        short_token_swap_path: Default::default(),
+        market_token_amount: 0,
+        min_long_token_amount: 0,
+        min_short_token_amount: 0,
+        updated_at_block: 0,
+        execution_fee: 0,
+        callback_gas_limit: 0,
+    };
+
+    let (caller_address, data_store, event_emitter, withdrawal_handler, withdrawal_vault_address) =
+        setup();
+    start_prank(withdrawal_handler.contract_address, caller_address);
+
+    let account = contract_address_const::<'account'>();
+    let key = contract_address_const::<'market'>();
+    let mut params = create_withrawal_params(key);
+
+    let market = Market {
+        market_token: key,
+        index_token: contract_address_const::<'index_token'>(),
+        long_token: contract_address_const::<'long_token'>(),
+        short_token: contract_address_const::<'short_token'>(),
+    };
+
+    data_store.set_market(key, 0, market);
+
+    start_mock_call(withdrawal_vault_address, 'record_transfer_in', 1);
+
+    let withdrawal_key = withdrawal_handler.create_withdrawal(account, params);
+
+    stop_mock_call(withdrawal_vault_address, 'record_transfer_in');
+    start_mock_call(data_store.contract_address, 'get_withdrawal', withdrawal);
+
+    // Key cleaning should be done in withdrawal_utils. We only check call here.
+    withdrawal_handler.cancel_withdrawal(withdrawal_key);
+}
+
+// This tests check withdrawal execution when caller address doesn't meet controller role
+// It calls withdrawal_handler.execute_withdrawal
+// The test expects the call to panic with the error 'unauthorized_access'.
 #[test]
 #[should_panic(expected: ('unauthorized_access',))]
 fn given_caller_not_controller_when_execute_withdrawal_then_fails() {
@@ -115,7 +276,7 @@ fn given_caller_not_controller_when_execute_withdrawal_then_fails() {
         price_feed_tokens: Default::default(),
     };
 
-    let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+    let (caller_address, data_store, event_emitter, withdrawal_handler, _) = setup();
 
     let withdrawal_key = 'SAMPLE_WITHDRAW';
 
@@ -141,7 +302,7 @@ fn given_caller_not_controller_when_execute_withdrawal_then_fails() {
 //         price_feed_tokens: Default::default(),
 //     };
 
-//     let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+//     let (caller_address, data_store, event_emitter, withdrawal_handler,_) = setup();
 //     let order_keeper = contract_address_const::<0x2233>();
 //     start_prank(withdrawal_handler.contract_address, order_keeper);
 
@@ -150,10 +311,13 @@ fn given_caller_not_controller_when_execute_withdrawal_then_fails() {
 //     withdrawal_handler.execute_withdrawal(withdrawal_key, oracle_params);
 // }
 
+// This tests check withdrawal simulation when when caller address doesn't meet controller role
+// It calls withdrawal_handler.simulate_execute_withdrawal
+// The test expects the call to panic with the error 'unauthorized_access'.
 #[test]
 #[should_panic(expected: ('unauthorized_access',))]
 fn given_caller_not_controller_when_simulate_execute_withdrawal_then_fails() {
-    let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+    let (caller_address, data_store, event_emitter, withdrawal_handler, _) = setup();
     let caller: ContractAddress = contract_address_const::<0x847>();
     start_prank(withdrawal_handler.contract_address, caller);
 
@@ -166,11 +330,13 @@ fn given_caller_not_controller_when_simulate_execute_withdrawal_then_fails() {
     withdrawal_handler.simulate_execute_withdrawal(withdrawal_key, oracle_params);
 }
 
-// Panics due to the absence of a mocked withdrawal, resulting in 'withdrawal not found'.
+// This tests check withdrawal simulation when key is unknown
+// It calls withdrawal_handler.simulate_execute_withdrawal
+// The test expects the call to panic with the error 'invalid withdrawal key','SAMPLE_WITHDRAW'.
 #[test]
 #[should_panic(expected: ('withdrawal not found',))]
 fn given_invalid_withdrawal_key_when_simulate_execute_withdrawal_then_fails() {
-    let (caller_address, data_store, event_emitter, withdrawal_handler) = setup();
+    let (caller_address, data_store, event_emitter, withdrawal_handler, _) = setup();
     let oracle_params = SimulatePricesParams {
         primary_tokens: Default::default(), primary_prices: Default::default(),
     };
@@ -302,7 +468,11 @@ fn deploy_event_emitter() -> ContractAddress {
 }
 
 fn setup() -> (
-    ContractAddress, IDataStoreDispatcher, IEventEmitterDispatcher, IWithdrawalHandlerDispatcher
+    ContractAddress,
+    IDataStoreDispatcher,
+    IEventEmitterDispatcher,
+    IWithdrawalHandlerDispatcher,
+    ContractAddress
 ) {
     let caller_address: ContractAddress = contract_address_const::<'caller'>();
     let order_keeper: ContractAddress = 0x2233.try_into().unwrap();
@@ -330,13 +500,14 @@ fn setup() -> (
         contract_address: withdrawal_handler_address
     };
     start_prank(role_store_address, caller_address);
-    role_store.grant_role(caller_address, role::MARKET_KEEPER);
     role_store.grant_role(caller_address, role::CONTROLLER);
     role_store.grant_role(order_keeper, role::ORDER_KEEPER);
+    role_store.grant_role(caller_address, role::MARKET_KEEPER);
     role_store.grant_role(withdrawal_handler_address, role::CONTROLLER);
     start_prank(data_store_address, caller_address);
 
     data_store.set_address(keys::fee_token(), fee_token_address);
+    //let market_token = IMarketTokenDispatcher { contract_address: market_token_address };
 
-    (caller_address, data_store, event_emitter, withdrawal_handler)
+    (caller_address, data_store, event_emitter, withdrawal_handler, withdrawal_vault_address)
 }

--- a/tests/exchange/test_withdrawal_handler.cairo
+++ b/tests/exchange/test_withdrawal_handler.cairo
@@ -23,7 +23,6 @@ use satoru::withdrawal::withdrawal_utils::CreateWithdrawalParams;
 use satoru::withdrawal::withdrawal::Withdrawal;
 use satoru::market::market::Market;
 use traits::Default;
-use debug::PrintTrait;
 
 // This tests check withdrawal creation under normal condition
 // It calls withdrawal_handler.create_withdrawal
@@ -309,8 +308,8 @@ fn given_caller_not_keeper_when_execute_withdrawal_then_fails() {
 }
 
 // TODO crashes because of gas_left function.
-//  #[test]
-//  #[should_panic(expected: ('invalid withdrawal key', 'SAMPLE_WITHDRAW'))]
+// #[test]
+// #[should_panic(expected: ('invalid withdrawal key', 'SAMPLE_WITHDRAW'))]
 // fn given_invalid_withdrawal_key_when_execute_withdrawal_then_fails() {
 //     let oracle_params = SetPricesParams {
 //         signer_info: Default::default(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Testing

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: https://github.com/keep-starknet-strange/satoru/issues/480

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Tests improved for create and cancel withdrawal

## Does this introduce a breaking change?

 No
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

Tests list for create and cancel withdrawal :

- given_normal_conditions_when_create_withdrawal_then_works
- given_market_token_amount_equal_zero_when_create_withdrawal_then_fails
- given_fee_token_lower_than_execution_fee_conditions_when_create_withdrawal_then_fails
- given_caller_not_controller_when_create_withdrawal_then_fails
- given_normal_conditions_when_cancel_withdrawal_then_works
- given_unexisting_key_when_cancel_withdrawal_then_fails
- given_account_address_zero_when_cancel_withdrawal_then_fails
- given_market_token_equals_zero_when_cancel_withdrawal_then_fails
- given_caller_not_controller_when_simulate_execute_withdrawal_then_fails
- given_invalid_withdrawal_key_when_simulate_execute_withdrawal_then_fails

TODO. Due to issue on entryPointSelector with oracle_modules::with_oracle_prices_before :
- given_normal_condition_when_execute_withdrawal_then_works
- given_invalid_withdrawal_key_when_execute_withdrawal_then_fails
