### PR TITLE
Use SCARB_VERSION in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.3.1"
+          scarb-version: ${{ env.SCARB_VERSION }}
       - uses: foundry-rs/setup-snfoundry@v2
         with:
           starknet-foundry-version: 0.10.1


### PR DESCRIPTION
`SCARB_VERSION` remained unused, could be a source of confusion if someone changed it expecting different scarb version to be used