### PR TITLE
add the pool_value_info.pool in the error message

### DIFF
--- a/src/deposit/execute_deposit_utils.cairo
+++ b/src/deposit/execute_deposit_utils.cairo
@@ -319,8 +319,8 @@ fn execute_deposit_helper(
 
     //TODO add the pool_value_info.pool in the error message
     if pool_value_info.pool_value < Zeroable::zero() {
-        panic_with_felt252(DepositError::INVALID_POOL_VALUE_FOR_DEPOSIT)
-    }
+    panic_with_felt252(DepositError::INVALID_POOL_VALUE_FOR_DEPOSIT(pool_value_info.pool_value));
+}
 
     let mut mint_amount = 0;
     let pool_value = to_unsigned(pool_value_info.pool_value);


### PR DESCRIPTION
TODO part seems to request adding the pool_value in the error message.

I included the pool_value in the error message in the event of an error related to an invalid pool value for deposit.
This modification takes the pool_value from pool_value_info and includes it in the error message when the condition for an invalid pool value is met