### PR TITLE
Adds test_deposit_event_emitted test

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,6 @@
       "extensions": ["starkware.cairo1"]
     }
   },
+  "runArgs": ["--memory=10g"],
   "postCreateCommand": "curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh && curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh -s -- -v 0.8.3"
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+
+[*.cairo]
+indent_style = space
+indent_size = 4
+
+

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -17,6 +17,9 @@ allowed-libfuncs-list.name = "experimental"
 [cairo]
 sierra-replace-ids = true
 
+[scripts]
+test = "snforge test"
+
 [dependencies]
 starknet = ">=2.3.1"
 alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria.git", tag = "cairo-v2.3.0-rc0" }

--- a/tests/event/test_deposit_event_emitted.cairo
+++ b/tests/event/test_deposit_event_emitted.cairo
@@ -1,0 +1,65 @@
+use starknet::{ContractAddress, contract_address_const};
+use snforge_std::{
+    declare, ContractClassTrait, spy_events, SpyOn, EventSpy, EventFetcher, event_name_hash, Event,
+    EventAssertions
+};
+
+use satoru::event::event_emitter::{
+    EventEmitter, IEventEmitterDispatcher, IEventEmitterDispatcherTrait
+};
+
+use satoru::event::event_emitter::EventEmitter::{
+  DepositCreated, DepositExecuted, DepositCancelled
+};
+
+use satoru::deposit::deposit::Deposit;
+use satoru::tests_lib::setup_event_emitter;
+
+// #[test]
+
+/// Utility function to setup the test environment.
+///
+/// # Returns
+///
+/// * `ContractAddress` - The address of the event emitter contract.
+/// * `IEventEmitterDispatcher` - The event emitter store dispatcher.
+fn setup() -> (ContractAddress, IEventEmitterDispatcher) {
+    let contract = declare('EventEmitter');
+    let contract_address = contract.deploy(@array![]).unwrap();
+    let event_emitter = IEventEmitterDispatcher { contract_address };
+    return (contract_address, event_emitter);
+}
+
+
+fn create_dummy_deposit_param() -> CreateDepositParams {
+    CreateDepositParams {
+        /// The address to send the market tokens to.
+        receiver: 'receiver'.try_into().unwrap(),
+        /// The callback contract linked to this deposit.
+        callback_contract: 'callback_contract'.try_into().unwrap(),
+        /// The ui fee receiver.
+        ui_fee_receiver: 'ui_fee_receiver'.try_into().unwrap(),
+        /// The market to deposit into.
+        market: 'market'.try_into().unwrap(),
+        /// The initial long token address.
+        initial_long_token: 'initial_long_token'.try_into().unwrap(),
+        /// The initial short token address.
+        initial_short_token: 'initial_short_token'.try_into().unwrap(),
+        /// The swap path into markets for the long token.
+        long_token_swap_path: array![
+            1.try_into().unwrap(), 2.try_into().unwrap(), 3.try_into().unwrap()
+        ]
+            .span32(),
+        /// The swap path into markets for the short token.
+        short_token_swap_path: array![
+            4.try_into().unwrap(), 5.try_into().unwrap(), 6.try_into().unwrap()
+        ]
+            .span32(),
+        /// The minimum acceptable number of liquidity tokens.
+        min_market_tokens: 10,
+        /// The execution fee for keepers.
+        execution_fee: 1,
+        /// The gas limit for the callback_contract.
+        callback_gas_limit: 20
+    }
+}

--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -29,6 +29,7 @@ mod event {
     mod test_adl_events_emitted;
     mod test_callback_events_emitted;
     mod test_config_events_emitted;
+    mod test_deposit_events_emitted;
     mod test_gas_events_emitted;
     mod test_market_events_emitted;
     mod test_oracle_events_emitted;


### PR DESCRIPTION
* adds tests for DepositEvents @ tests/event/test_deposit_event_emitted.cairo
* adds scarb test script entry on Scarb.toml 
* adjusts  `devcontainer` memory to fit `scarb compile`
* adds `.editorconfig` for specifying 

# Pull Request type
Please add the labels corresponding to the type of changes your PR introduces:
- Testing

## What is the current behavior?
Missing tests for `DepositEvents` functions of the `EventEmitter` contract
Resolves: #322 

## What is the new behavior?

add tests for `DepositEvents` functions of the `EventEmitter` contract

- Test for emit_deposit_created using spy_events must be included
- Test for emit_deposit_executed using spy_events must be included
- Test for emit_deposit_cancelled using spy_events must be included

## Does this introduce a breaking change?
No

## Other information
Some optional tweaks submitted for consideration:
Increasing memory for the devcontainer 
Including a  .editorconfig (form editorconfig.org)