### PR TITLE
Add increment of cur_idx in with_simulated_oracle_prices_before function

### DIFF
--- a/src/oracle/oracle_modules.cairo
+++ b/src/oracle/oracle_modules.cairo
@@ -68,6 +68,7 @@ fn with_simulated_oracle_prices_before(oracle: IOracleDispatcher, params: Simula
         let token: ContractAddress = *params.primary_tokens.at(cur_idx);
         let price: Price = *params.primary_prices.at(cur_idx);
         oracle.set_primary_price(token, price);
+        cur_idx = cur_idx + 1;
     };
 }
 

--- a/src/oracle/oracle_modules.cairo
+++ b/src/oracle/oracle_modules.cairo
@@ -60,7 +60,7 @@ fn with_simulated_oracle_prices_before(oracle: IOracleDispatcher, params: Simula
             params.primary_tokens.len(), params.primary_prices.len()
         );
     }
-    let cur_idx = 0;
+    let mut cur_idx = 0;
     loop {
         if (cur_idx == params.primary_tokens.len()) {
             break ();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #602 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Loop through all `params.primary_tokens.len()` when run `with_simulated_oracle_prices_before function` in `oracle_modules.cairo`

## Does this introduce a breaking change?

No

