### PR TITLE
Fix bug List index out of bounds when remove last index element in Datastore

### DIFF
--- a/src/data/data_store.cairo
+++ b/src/data/data_store.cairo
@@ -1512,6 +1512,9 @@ mod DataStore {
                             if account_withdrawals.len() == 0 {
                                 break;
                             }
+                            if last_key == withdrawal_key {
+                                break;
+                            }
                             account_withdrawals.set(i, last_key);
                         },
                         Option::None => {
@@ -1539,6 +1542,9 @@ mod DataStore {
                         Option::Some(last_key) => {
                             // If the list is empty, then there's no need to replace an existing key
                             if account_orders.len() == 0 {
+                                break;
+                            }
+                            if last_key == order_key {
                                 break;
                             }
                             account_orders.set(i, last_key);
@@ -1572,6 +1578,9 @@ mod DataStore {
                             if account_deposits.len() == 0 {
                                 break;
                             }
+                            if last_key == deposit_key {
+                                break;
+                            }
                             account_deposits.set(i, last_key);
                         },
                         Option::None => {
@@ -1601,6 +1610,9 @@ mod DataStore {
                         Option::Some(last_key) => {
                             // If the list is empty, then there's no need to replace an existing key
                             if account_positions.len() == 0 {
+                                break;
+                            }
+                            if last_key == position_key {
                                 break;
                             }
                             account_positions.set(i, last_key);

--- a/tests/data/test_deposit_store.cairo
+++ b/tests/data/test_deposit_store.cairo
@@ -271,6 +271,60 @@ fn given_normal_conditions_when_remove_1_of_n_deposit_then_works() {
     teardown(data_store.contract_address);
 }
 
+#[test]
+fn given_normal_conditions_when_remove_last_deposit_then_works() {
+    // Setup
+    let (caller_address, role_store, data_store) = setup();
+    let key_1: felt252 = 123456789;
+    let account = 'account'.try_into().unwrap();
+    let mut deposit_1: Deposit = create_new_deposit(
+        key_1,
+        account,
+        contract_address_const::<'receiver1'>(),
+        contract_address_const::<'market1'>(),
+        deposit_no: 1
+    );
+
+    let key_2: felt252 = 22222222222;
+
+    let mut deposit_2: Deposit = create_new_deposit(
+        key_2,
+        account,
+        contract_address_const::<'receiver1'>(),
+        contract_address_const::<'market1'>(),
+        deposit_no: 1
+    );
+
+    data_store.set_deposit(key_1, deposit_1);
+    data_store.set_deposit(key_2, deposit_2);
+
+    let deposit_count = data_store.get_deposit_count();
+    assert(deposit_count == 2, 'Invalid key deposit count');
+
+    let account_deposit_count = data_store.get_account_deposit_count(account);
+    assert(account_deposit_count == 2, 'Acc deposit # should be 2');
+    // Given
+    data_store.remove_deposit(key_2, account);
+
+    // Then
+    let deposit_1_by_key = data_store.get_deposit(key_1);
+    assert(deposit_1_by_key.account.is_non_zero(), 'deposit1 shouldnt be removed');
+
+    let deposit_2_by_key = data_store.get_deposit(key_2);
+    assert(deposit_2_by_key.account.is_zero(), 'deposit2 should be removed');
+
+    let deposit_count = data_store.get_deposit_count();
+    assert(deposit_count == 1, 'deposit # should be 1');
+
+    let account_deposit_count = data_store.get_account_deposit_count(account);
+    assert(account_deposit_count == 1, 'Acc deposit # should be 1');
+
+    let account_deposit_keys = data_store.get_account_deposit_keys(account, 0, 10);
+    assert(account_deposit_keys.len() == 1, 'Acc withdraw # not 1');
+
+    teardown(data_store.contract_address);
+}
+
 
 #[test]
 #[should_panic(expected: ('unauthorized_access',))]

--- a/tests/data/test_order.cairo
+++ b/tests/data/test_order.cairo
@@ -242,10 +242,70 @@ fn given_normal_conditions_when_remove_1_of_n_order_then_works() {
 
     // Then
     let order_1_by_key = data_store.get_order(key_1);
-    assert(order_1_by_key.account.is_zero(), 'order1 shouldnt be removed');
+    assert(order_1_by_key.account.is_zero(), 'order1 should be removed');
 
     let order_2_by_key = data_store.get_order(key_2);
     assert(order_2_by_key.account.is_non_zero(), 'order2 shouldnt be removed');
+
+    let order_count = data_store.get_order_count();
+    assert(order_count == 1, 'order # should be 1');
+
+    let account_order_count = data_store.get_account_order_count(account);
+    assert(account_order_count == 1, 'Acc order # should be 1');
+
+    let account_order_keys = data_store.get_account_order_keys(account, 0, 10);
+    assert(account_order_keys.len() == 1, 'Acc withdraw # not 1');
+
+    teardown(data_store.contract_address);
+}
+
+#[test]
+fn given_normal_conditions_when_remove_last_order_then_works() {
+    // Setup
+    let (caller_address, role_store, data_store) = setup();
+    let key_1: felt252 = 123456789;
+    let account = 'account'.try_into().unwrap();
+    let mut order_1: Order = create_new_order(
+        key_1,
+        account,
+        contract_address_const::<'receiver1'>(),
+        contract_address_const::<'market1'>(),
+        contract_address_const::<'token1'>(),
+        is_long: false,
+        is_frozen: false,
+        order_no: 1
+    );
+
+    let key_2: felt252 = 22222222222;
+
+    let mut order_2: Order = create_new_order(
+        key_2,
+        account,
+        contract_address_const::<'receiver1'>(),
+        contract_address_const::<'market1'>(),
+        contract_address_const::<'token1'>(),
+        is_long: false,
+        is_frozen: false,
+        order_no: 1
+    );
+
+    data_store.set_order(key_1, order_1);
+    data_store.set_order(key_2, order_2);
+
+    let order_count = data_store.get_order_count();
+    assert(order_count == 2, 'Invalid key order count');
+
+    let account_order_count = data_store.get_account_order_count(account);
+    assert(account_order_count == 2, 'Acc order # should be 2');
+    // Given
+    data_store.remove_order(key_2, account);
+
+    // Then
+    let order_1_by_key = data_store.get_order(key_1);
+    assert(order_1_by_key.account.is_non_zero(), 'order1 shouldnt be removed');
+
+    let order_2_by_key = data_store.get_order(key_2);
+    assert(order_2_by_key.account.is_zero(), 'order2 should be removed');
 
     let order_count = data_store.get_order_count();
     assert(order_count == 1, 'order # should be 1');

--- a/tests/data/test_position.cairo
+++ b/tests/data/test_position.cairo
@@ -242,6 +242,61 @@ fn given_normal_conditions_when_remove_1_of_n_position_then_works() {
     teardown(data_store.contract_address);
 }
 
+#[test]
+fn given_normal_conditions_when_remove_last_position_then_works() {
+    // Setup
+    let (caller_address, role_store, data_store) = setup();
+    let key_1: felt252 = 123456789;
+    let account = 'account'.try_into().unwrap();
+    let mut position_1: Position = create_new_position(
+        key_1,
+        account,
+        contract_address_const::<'market1'>(),
+        contract_address_const::<'token1'>(),
+        is_long: false,
+        position_no: 1
+    );
+
+    let key_2: felt252 = 22222222222;
+    let mut position_2: Position = create_new_position(
+        key_2,
+        account,
+        contract_address_const::<'market1'>(),
+        contract_address_const::<'token1'>(),
+        is_long: false,
+        position_no: 1
+    );
+
+    data_store.set_position(key_1, position_1);
+    data_store.set_position(key_2, position_2);
+
+    let position_count = data_store.get_position_count();
+    assert(position_count == 2, 'Invalid key position count');
+
+    let account_position_count = data_store.get_account_position_count(account);
+    assert(account_position_count == 2, 'Acc position # should be 2');
+    // Given
+    data_store.remove_position(key_2, account);
+
+    // Then
+    let position_1_by_key = data_store.get_position(key_1);
+    assert(position_1_by_key.account.is_non_zero(), 'position1 shouldnt be removed');
+
+    let position_2_by_key = data_store.get_position(key_2);
+    assert(position_2_by_key.account.is_zero(), 'position2 should be removed');
+
+    let position_count = data_store.get_position_count();
+    assert(position_count == 1, 'position # should be 1');
+
+    let account_position_count = data_store.get_account_position_count(account);
+    assert(account_position_count == 1, 'Acc position # should be 1');
+
+    let account_position_keys = data_store.get_account_position_keys(account, 0, 10);
+    assert(account_position_keys.len() == 1, 'Acc position # not 1');
+
+    teardown(data_store.contract_address);
+}
+
 
 #[test]
 #[should_panic(expected: ('unauthorized_access',))]

--- a/tests/data/test_withdrawal.cairo
+++ b/tests/data/test_withdrawal.cairo
@@ -379,6 +379,78 @@ fn given_normal_conditions_when_remove_1_of_n_withdrawal_then_works() {
     teardown(data_store.contract_address);
 }
 
+#[test]
+fn given_normal_conditions_when_remove_last_withdrawal_then_works() {
+    // Setup
+    let (caller_address, role_store, data_store) = setup();
+    let account = 'account'.try_into().unwrap();
+    let long_token_swap_path: Span32<ContractAddress> = array![
+        1.try_into().unwrap(), 2.try_into().unwrap(), 3.try_into().unwrap()
+    ]
+        .span32();
+    let short_token_swap_path: Span32<ContractAddress> = array![
+        4.try_into().unwrap(), 5.try_into().unwrap(), 6.try_into().unwrap()
+    ]
+        .span32();
+
+    let key_1: felt252 = 123456789;
+    let mut withdrawal_1 = Withdrawal {
+        key: key_1,
+        account,
+        receiver: account,
+        callback_contract: 1.try_into().unwrap(),
+        ui_fee_receiver: 1.try_into().unwrap(),
+        market: 1.try_into().unwrap(),
+        long_token_swap_path,
+        short_token_swap_path,
+        market_token_amount: 1,
+        min_long_token_amount: 1,
+        min_short_token_amount: 1,
+        updated_at_block: 1,
+        execution_fee: 1,
+        callback_gas_limit: 1,
+    };
+
+    let key_2: felt252 = 987654321;
+    let mut withdrawal_2 = Withdrawal {
+        key: key_2,
+        account,
+        receiver: account,
+        callback_contract: 1.try_into().unwrap(),
+        ui_fee_receiver: 1.try_into().unwrap(),
+        market: 1.try_into().unwrap(),
+        long_token_swap_path,
+        short_token_swap_path,
+        market_token_amount: 1,
+        min_long_token_amount: 1,
+        min_short_token_amount: 1,
+        updated_at_block: 1,
+        execution_fee: 1,
+        callback_gas_limit: 1,
+    };
+
+    data_store.set_withdrawal(key_1, withdrawal_1);
+    data_store.set_withdrawal(key_2, withdrawal_2);
+
+    // Given
+    data_store.remove_withdrawal(key_2, account);
+
+    // Then
+    let withdrawal_1_by_key = data_store.get_withdrawal(key_1);
+    assert(withdrawal_1_by_key.account.is_non_zero(), 'withdrawal1 shouldnt be removed');
+
+    let withdrawal_2_by_key = data_store.get_withdrawal(key_2);
+    assert(withdrawal_2_by_key.account.is_zero(), 'withdrawal2 should be removed');
+
+    let account_withdrawal_count = data_store.get_account_withdrawal_count(account);
+    assert(account_withdrawal_count == 1, 'Acc withdrawal # should be 1');
+
+    let account_withdrawal_keys = data_store.get_account_withdrawal_keys(account, 0, 10);
+    assert(account_withdrawal_keys.len() == 1, 'Acc withdraw # not 1');
+
+    teardown(data_store.contract_address);
+}
+
 
 #[test]
 #[should_panic(expected: ('unauthorized_access',))]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Testing

## What is the current behavior?

- List index out of bounds when remove last index element of deposit, withdrawal, order, position in Datastore

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #607 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Able to remove last element of deposit, withdrawal, order, position in Datastore

## Does this introduce a breaking change?

No
