### PR TITLE
Update Semgrep Rules and Semgrep config path for CI

### DIFF
--- a/.github/semgrep-cairo-rules.yaml
+++ b/.github/semgrep-cairo-rules.yaml
@@ -13,3 +13,34 @@ rules:
     - pattern-regex: $Y / $X
     - pattern-not-regex: error_utils::check_division_by_zero
     
+- id: reentrancy
+  message: |
+    Value mutated after call to external contract
+  severity: ERROR
+  mode: join
+  join:
+    rules:
+      - id: external-contract-declaration
+        languages: [cairo]
+        pattern: |
+          trait $SOME_CONTRACT {}
+      - id: external-call
+        languages: [cairo]
+        pattern: |
+          $SOME_CONTRACT::transfer(...);
+          ...;
+          $X::write(...);
+    on:
+      - 'external-contract-declaration.$SOME_CONTRACT == external-call.$SOME_CONTRACT'
+      
+- id: unsafe-arithmetic
+  message: Call unsafe math operators on $X
+  languages: [cairo]
+  severity: ERROR
+  pattern-either:
+  - pattern: $X + $Y
+  - pattern: $X += ...
+  - pattern: $X - $Y
+  - pattern: $X -= ...
+  - pattern: $X * $Y
+  - pattern: $X *= ...

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           pip install semgrep==1.45.0
       - name: Run Semgrep
-        run: semgrep --config https://github.com/avnu-labs/semgrep-cairo-rules/releases/download/v0.0.1/cairo-rules.yaml ./src > semgrep-output.txt
+        run: semgrep --config .github/semgrep-cairo-rules.yaml ./src > semgrep-output.txt
       - name: Save Semgrep Output as an Artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

- Build-related changes

## What is the current behavior?

Currently, our CI workflow is using AVNU Semgrep rules.

Resolves: #455 

## What is the new behavior?

This PR integrates Avnu semgrep rules with new semgrep rules from https://github.com/keep-starknet-strange/satoru/pull/453 into our GitHub Actions CI workflow.

## Does this introduce a breaking change?

No. This change only affects the CI workflow and does not alter the application's functionality or API.