### PR TITLE
fix: global_reentrancy_guard duplicate exchange_router và Handler

### DIFF
--- a/src/exchange/deposit_handler.cairo
+++ b/src/exchange/deposit_handler.cairo
@@ -156,7 +156,7 @@ mod DepositHandler {
             IRoleModule::only_controller(@state);
 
             let data_store = self.data_store.read();
-            global_reentrancy_guard::non_reentrant_before(data_store);
+
 
             feature_utils::validate_feature(
                 self.data_store.read(),
@@ -171,7 +171,7 @@ mod DepositHandler {
                 params
             );
 
-            global_reentrancy_guard::non_reentrant_after(data_store);
+            
 
             key
         }
@@ -181,7 +181,7 @@ mod DepositHandler {
             IRoleModule::only_controller(@state);
 
             let data_store = self.data_store.read();
-            global_reentrancy_guard::non_reentrant_before(data_store);
+            
 
             // let starting_gas = gas_left();
 
@@ -204,8 +204,6 @@ mod DepositHandler {
                 keys::user_initiated_cancel(),
                 array!['Cancel Deposit'] //TODO should be empty string
             );
-
-            global_reentrancy_guard::non_reentrant_after(data_store);
         }
 
         fn execute_deposit(ref self: ContractState, key: felt252, oracle_params: SetPricesParams) {
@@ -237,7 +235,7 @@ mod DepositHandler {
 
             let data_store = self.data_store.read();
             let oracle = self.oracle.read();
-            global_reentrancy_guard::non_reentrant_before(data_store);
+            
             oracle_modules::with_simulated_oracle_prices_before(oracle, params);
 
             let oracleParams = Default::default();
@@ -245,7 +243,6 @@ mod DepositHandler {
             self.execute_deposit_keeper(key, oracleParams, get_caller_address());
 
             oracle_modules::with_simulated_oracle_prices_after();
-            global_reentrancy_guard::non_reentrant_after(data_store);
         }
 
         fn execute_deposit_keeper(

--- a/src/exchange/order_handler.cairo
+++ b/src/exchange/order_handler.cairo
@@ -202,8 +202,6 @@ mod OrderHandler {
             let base_order_handler_state = BaseOrderHandler::unsafe_new_contract_state();
             let data_store = base_order_handler_state.data_store.read();
 
-            global_reentrancy_guard::non_reentrant_before(data_store);
-
             // Validate feature and create order.
             feature_utils::validate_feature(
                 data_store,
@@ -217,8 +215,6 @@ mod OrderHandler {
                 account,
                 params
             );
-
-            global_reentrancy_guard::non_reentrant_after(data_store);
 
             key
         }
@@ -241,7 +237,7 @@ mod OrderHandler {
             let data_store = base_order_handler_state.data_store.read();
             let event_emitter = base_order_handler_state.event_emitter.read();
 
-            global_reentrancy_guard::non_reentrant_before(data_store);
+           
 
             // Validate feature.
             feature_utils::validate_feature(
@@ -281,7 +277,7 @@ mod OrderHandler {
                     key, size_delta_usd, acceptable_price, trigger_price, min_output_amount
                 );
 
-            global_reentrancy_guard::non_reentrant_after(data_store);
+            
 
             updated_order
         }
@@ -297,7 +293,7 @@ mod OrderHandler {
             let base_order_handler_state = BaseOrderHandler::unsafe_new_contract_state();
             let data_store = base_order_handler_state.data_store.read();
 
-            global_reentrancy_guard::non_reentrant_before(data_store);
+            
 
             let order = data_store.get_order(key);
 
@@ -324,7 +320,7 @@ mod OrderHandler {
                 ArrayTrait::<felt252>::new(),
             );
 
-            global_reentrancy_guard::non_reentrant_after(data_store);
+            
         }
 
         fn execute_order(ref self: ContractState, key: felt252, oracle_params: SetPricesParams) {
@@ -361,15 +357,15 @@ mod OrderHandler {
         fn simulate_execute_order(
             ref self: ContractState, key: felt252, params: SimulatePricesParams
         ) {
-            // Check only order keeper.
+            // Check only controller.
             let role_module_state = RoleModule::unsafe_new_contract_state();
-            role_module_state.only_order_keeper();
+            role_module_state.only_controller();
 
             // Fetch data store.
             let base_order_handler_state = BaseOrderHandler::unsafe_new_contract_state();
             let data_store = base_order_handler_state.data_store.read();
 
-            global_reentrancy_guard::non_reentrant_before(data_store);
+
             oracle_modules::with_simulated_oracle_prices_before(
                 base_order_handler_state.oracle.read(), params
             );
@@ -378,7 +374,6 @@ mod OrderHandler {
             self._execute_order(key, oracle_params, get_contract_address());
 
             oracle_modules::with_simulated_oracle_prices_after();
-            global_reentrancy_guard::non_reentrant_after(data_store);
         }
     }
 

--- a/src/exchange/withdrawal_handler.cairo
+++ b/src/exchange/withdrawal_handler.cairo
@@ -148,7 +148,7 @@ mod WithdrawalHandler {
 
             let data_store = self.data_store.read();
 
-            global_reentrancy_guard::non_reentrant_before(data_store); // Initiates re-entrancy
+            
 
             feature_utils::validate_feature(
                 data_store, keys::create_withdrawal_feature_disabled_key(get_contract_address())
@@ -158,7 +158,7 @@ mod WithdrawalHandler {
                 data_store, self.event_emitter.read(), self.withdrawal_vault.read(), account, params
             );
 
-            global_reentrancy_guard::non_reentrant_after(data_store); // Finalizes re-entrancy
+            
 
             result
         }
@@ -172,7 +172,7 @@ mod WithdrawalHandler {
 
             let data_store = self.data_store.read();
 
-            global_reentrancy_guard::non_reentrant_before(data_store); // Initiates re-entrancy
+            
 
             let starting_gas = starknet_utils::sn_gasleft(array![200]); // Returns 200 for now,
             let withdrawal = data_store.get_withdrawal(key);
@@ -196,7 +196,7 @@ mod WithdrawalHandler {
                 array![]
             );
 
-            global_reentrancy_guard::non_reentrant_after(data_store); // Finalizes re-entrancy
+            
         }
 
         fn execute_withdrawal(
@@ -260,7 +260,7 @@ mod WithdrawalHandler {
 
             let data_store = self.data_store.read();
 
-            global_reentrancy_guard::non_reentrant_before(data_store); // Initiates re-entrancy
+            
 
             let oracle_params: SetPricesParams = SetPricesParams {
                 signer_info: 0,
@@ -279,7 +279,7 @@ mod WithdrawalHandler {
 
             self.execute_withdrawal_keeper(key, oracle_params, get_caller_address());
 
-            global_reentrancy_guard::non_reentrant_after(data_store); // Finalizes re-entrancy
+            
 
             oracle_modules::with_simulated_oracle_prices_after();
         }


### PR DESCRIPTION
# Fix duplicate global_reentrancy_guard

# Pull Request type

- Bugfix
- Testing

## What is the current behavior?
- `ReentrancyGuard: reentrant call` when create_order, cancel_order, simulate_execute_order, create_deposit, cancel_deposit, simulate_execute_deposit, create_withdrawal, cancel_withdrawal, simulate_execute_withdrawal

Resolves: #624

## What is the new behavior?
- Able to create + cancel + simulate order, deposit, withdrawal


## Does this introduce a breaking change?
No
