### PR TITLE
feat: use library calls

### DIFF
--- a/src/exchange/liquidation_handler.cairo
+++ b/src/exchange/liquidation_handler.cairo
@@ -41,7 +41,7 @@ mod LiquidationHandler {
 
     // Core lib imports.
 
-    use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use starknet::{ContractAddress, get_caller_address, get_contract_address, ClassHash};
 
 
     // Local imports.
@@ -109,7 +109,10 @@ mod LiquidationHandler {
         oracle_address: ContractAddress,
         swap_handler_address: ContractAddress,
         referral_storage_address: ContractAddress,
-        order_utils_address: ContractAddress
+        order_utils_class_hash: ClassHash,
+        increase_order_utils_class_hash: ClassHash,
+        decrease_order_utils_class_hash: ClassHash,
+        swap_order_utils_class_hash: ClassHash,
     ) {
         let mut state: BaseOrderHandler::ContractState =
             BaseOrderHandler::unsafe_new_contract_state();
@@ -122,7 +125,10 @@ mod LiquidationHandler {
             oracle_address,
             swap_handler_address,
             referral_storage_address,
-            order_utils_address
+            order_utils_class_hash,
+            increase_order_utils_class_hash: ClassHash,
+            decrease_order_utils_class_hash: ClassHash,
+            swap_order_utils_class_hash: ClassHash,
         );
         let mut state: RoleModule::ContractState = RoleModule::unsafe_new_contract_state();
         IRoleModule::initialize(ref state, role_store_address,);

--- a/src/exchange/order_handler.cairo
+++ b/src/exchange/order_handler.cairo
@@ -100,11 +100,12 @@ mod OrderHandler {
     // *************************************************************************
 
     // Core lib imports.
+    use satoru::exchange::base_order_handler::BaseOrderHandler::order_utils_lib::InternalContractMemberStateTrait;
     use satoru::order::order_utils::IOrderUtilsDispatcherTrait;
     use core::starknet::SyscallResultTrait;
     use core::traits::Into;
     use starknet::ContractAddress;
-    use starknet::{get_caller_address, get_contract_address};
+    use starknet::{get_caller_address, get_contract_address, ClassHash};
     use array::ArrayTrait;
     use debug::PrintTrait;
 
@@ -133,7 +134,6 @@ mod OrderHandler {
         order_vault::InternalContractMemberStateTrait as OrderVaultStateTrait,
         referral_storage::InternalContractMemberStateTrait as ReferralStorageStateTrait,
         oracle::InternalContractMemberStateTrait as OracleStateTrait,
-        order_utils::InternalContractMemberStateTrait as OrderUtilsTrait,
         InternalTrait as BaseOrderHandleInternalTrait,
     };
     use satoru::feature::feature_utils::{validate_feature};
@@ -178,7 +178,10 @@ mod OrderHandler {
         oracle_address: ContractAddress,
         swap_handler_address: ContractAddress,
         referral_storage_address: ContractAddress,
-        order_utils_address: ContractAddress
+        order_utils_class_hash: ClassHash,
+        increase_order_utils_class_hash: ClassHash,
+        decrease_order_utils_class_hash: ClassHash,
+        swap_order_utils_class_hash: ClassHash,
     ) {
         let mut state: BaseOrderHandler::ContractState =
             BaseOrderHandler::unsafe_new_contract_state();
@@ -191,7 +194,10 @@ mod OrderHandler {
             oracle_address,
             swap_handler_address,
             referral_storage_address,
-            order_utils_address
+            order_utils_class_hash,
+            increase_order_utils_class_hash,
+            decrease_order_utils_class_hash,
+            swap_order_utils_class_hash
         );
     }
 
@@ -219,7 +225,7 @@ mod OrderHandler {
                 create_order_feature_disabled_key(get_contract_address(), params.order_type)
             );
             let key = base_order_handler_state
-                .order_utils
+                .order_utils_lib
                 .read()
                 .create_order_utils(
                     data_store,
@@ -327,7 +333,7 @@ mod OrderHandler {
                 execute_order_feature_disabled_key(get_contract_address(), params.order.order_type)
             );
 
-            base_order_handler_state.order_utils.read().execute_order_utils(params);
+            base_order_handler_state.order_utils_lib.read().execute_order_utils(params);
         }
 
 

--- a/tests/integration/swap_test.cairo
+++ b/tests/integration/swap_test.cairo
@@ -1265,13 +1265,12 @@ fn setup_contracts() -> (
 
     let swap_handler_address = deploy_swap_handler_address(role_store_address, data_store_address);
     let referral_storage_address = deploy_referral_storage(event_emitter_address);
-    let increase_order_address = deploy_increase_order();
-    let decrease_order_address = deploy_decrease_order();
-    let swap_order_address = deploy_swap_order();
+    let increase_order_class_hash = declare_increase_order();
+    let decrease_order_class_hash = declare_decrease_order();
+    let swap_order_class_hash = declare_swap_order();
 
-    let order_utils_address = deploy_order_utils(
-        increase_order_address, decrease_order_address, swap_order_address
-    );
+    let order_utils_class_hash = declare_order_utils();
+
     let order_handler_address = deploy_order_handler(
         data_store_address,
         role_store_address,
@@ -1280,7 +1279,10 @@ fn setup_contracts() -> (
         oracle_address,
         swap_handler_address,
         referral_storage_address,
-        order_utils_address
+        order_utils_class_hash,
+        increase_order_class_hash,
+        decrease_order_class_hash,
+        swap_order_class_hash
     );
     let order_handler = IOrderHandlerDispatcher { contract_address: order_handler_address };
 
@@ -1487,6 +1489,21 @@ fn deploy_withdrawal_vault(
     contract.deploy_at(@constructor_calldata, deployed_contract_address).unwrap()
 }
 
+fn declare_increase_order() -> ClassHash {
+    declare('IncreaseOrderUtils').class_hash
+}
+fn declare_decrease_order() -> ClassHash {
+    declare('DecreaseOrderUtils').class_hash
+}
+fn declare_swap_order() -> ClassHash {
+    declare('SwapOrderUtils').class_hash
+}
+
+
+fn declare_order_utils() -> ClassHash {
+    declare('OrderUtils').class_hash
+}
+
 fn deploy_order_handler(
     data_store_address: ContractAddress,
     role_store_address: ContractAddress,
@@ -1495,7 +1512,10 @@ fn deploy_order_handler(
     oracle_address: ContractAddress,
     swap_handler_address: ContractAddress,
     referral_storage_address: ContractAddress,
-    order_utils_address: ContractAddress
+    order_utils_class_hash: ClassHash,
+    increase_order_class_hash: ClassHash,
+    decrease_order_class_hash: ClassHash,
+    swap_order_class_hash: ClassHash
 ) -> ContractAddress {
     let contract = declare('OrderHandler');
     let caller_address: ContractAddress = contract_address_const::<'caller'>();
@@ -1509,7 +1529,10 @@ fn deploy_order_handler(
         oracle_address.into(),
         swap_handler_address.into(),
         referral_storage_address.into(),
-        order_utils_address.into()
+        order_utils_class_hash.into(),
+        increase_order_class_hash.into(),
+        decrease_order_class_hash.into(),
+        swap_order_class_hash.into()
     ];
     contract.deploy_at(@constructor_calldata, deployed_contract_address).unwrap()
 }
@@ -1567,50 +1590,6 @@ fn deploy_order_vault(
     constructor_calldata.append(data_store_address.into());
     constructor_calldata.append(role_store_address.into());
     tests_lib::deploy_mock_contract(contract, @constructor_calldata)
-}
-
-fn deploy_increase_order() -> ContractAddress {
-    let contract = declare('IncreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'increase_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
-}
-fn deploy_decrease_order() -> ContractAddress {
-    let contract = declare('DecreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'decrease_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
-}
-fn deploy_swap_order() -> ContractAddress {
-    let contract = declare('SwapOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'swap_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
-}
-
-
-fn deploy_order_utils(
-    increase_order_address: ContractAddress,
-    decrease_order_address: ContractAddress,
-    swap_order_address: ContractAddress,
-) -> ContractAddress {
-    let contract = declare('OrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract
-        .deploy_at(
-            @array![
-                increase_order_address.into(),
-                decrease_order_address.into(),
-                swap_order_address.into()
-            ],
-            deployed_contract_address
-        )
-        .unwrap()
 }
 
 fn deploy_bank(

--- a/tests/integration/test_deposit_withdrawal.cairo
+++ b/tests/integration/test_deposit_withdrawal.cairo
@@ -1166,13 +1166,12 @@ fn setup_contracts() -> (
 
     let swap_handler_address = deploy_swap_handler_address(role_store_address, data_store_address);
     let referral_storage_address = deploy_referral_storage(event_emitter_address);
-    let increase_order_address = deploy_increase_order();
-    let decrease_order_address = deploy_decrease_order();
-    let swap_order_address = deploy_swap_order();
+    let increase_order_class_hash = declare_increase_order();
+    let decrease_order_class_hash = declare_decrease_order();
+    let swap_order_class_hash = declare_swap_order();
 
-    let order_utils_address = deploy_order_utils(
-        increase_order_address, decrease_order_address, swap_order_address
-    );
+    let order_utils_class_hash = declare_order_utils();
+
     let order_handler_address = deploy_order_handler(
         data_store_address,
         role_store_address,
@@ -1181,7 +1180,10 @@ fn setup_contracts() -> (
         oracle_address,
         swap_handler_address,
         referral_storage_address,
-        order_utils_address
+        order_utils_class_hash,
+        increase_order_class_hash,
+        decrease_order_class_hash,
+        swap_order_class_hash
     );
     let order_handler = IOrderHandlerDispatcher { contract_address: order_handler_address };
 
@@ -1371,50 +1373,6 @@ fn deploy_deposit_vault(
         .unwrap()
 }
 
-fn deploy_increase_order() -> ContractAddress {
-    let contract = declare('IncreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'increase_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
-}
-fn deploy_decrease_order() -> ContractAddress {
-    let contract = declare('DecreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'decrease_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
-}
-fn deploy_swap_order() -> ContractAddress {
-    let contract = declare('SwapOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'swap_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
-}
-
-
-fn deploy_order_utils(
-    increase_order_address: ContractAddress,
-    decrease_order_address: ContractAddress,
-    swap_order_address: ContractAddress,
-) -> ContractAddress {
-    let contract = declare('OrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract
-        .deploy_at(
-            @array![
-                increase_order_address.into(),
-                decrease_order_address.into(),
-                swap_order_address.into()
-            ],
-            deployed_contract_address
-        )
-        .unwrap()
-}
-
 fn deploy_withdrawal_handler(
     data_store_address: ContractAddress,
     role_store_address: ContractAddress,
@@ -1447,6 +1405,21 @@ fn deploy_withdrawal_vault(
     contract.deploy_at(@constructor_calldata, deployed_contract_address).unwrap()
 }
 
+fn declare_increase_order() -> ClassHash {
+    declare('IncreaseOrderUtils').class_hash
+}
+fn declare_decrease_order() -> ClassHash {
+    declare('DecreaseOrderUtils').class_hash
+}
+fn declare_swap_order() -> ClassHash {
+    declare('SwapOrderUtils').class_hash
+}
+
+
+fn declare_order_utils() -> ClassHash {
+    declare('OrderUtils').class_hash
+}
+
 fn deploy_order_handler(
     data_store_address: ContractAddress,
     role_store_address: ContractAddress,
@@ -1455,7 +1428,10 @@ fn deploy_order_handler(
     oracle_address: ContractAddress,
     swap_handler_address: ContractAddress,
     referral_storage_address: ContractAddress,
-    order_utils_address: ContractAddress
+    order_utils_class_hash: ClassHash,
+    increase_order_class_hash: ClassHash,
+    decrease_order_class_hash: ClassHash,
+    swap_order_class_hash: ClassHash
 ) -> ContractAddress {
     let contract = declare('OrderHandler');
     let caller_address: ContractAddress = contract_address_const::<'caller'>();
@@ -1469,7 +1445,10 @@ fn deploy_order_handler(
         oracle_address.into(),
         swap_handler_address.into(),
         referral_storage_address.into(),
-        order_utils_address.into()
+        order_utils_class_hash.into(),
+        increase_order_class_hash.into(),
+        decrease_order_class_hash.into(),
+        swap_order_class_hash.into()
     ];
     contract.deploy_at(@constructor_calldata, deployed_contract_address).unwrap()
 }

--- a/tests/integration/test_long_integration.cairo
+++ b/tests/integration/test_long_integration.cairo
@@ -2333,13 +2333,11 @@ fn setup_contracts() -> (
 
     let swap_handler_address = deploy_swap_handler_address(role_store_address, data_store_address);
     let referral_storage_address = deploy_referral_storage(event_emitter_address);
-    let increase_order_address = deploy_increase_order();
-    let decrease_order_address = deploy_decrease_order();
-    let swap_order_address = deploy_swap_order();
+    let increase_order_class_hash = declare_increase_order();
+    let decrease_order_class_hash = declare_decrease_order();
+    let swap_order_class_hash = declare_swap_order();
 
-    let order_utils_address = deploy_order_utils(
-        increase_order_address, decrease_order_address, swap_order_address
-    );
+    let order_utils_class_hash = declare_order_utils();
 
     let order_handler_address = deploy_order_handler(
         data_store_address,
@@ -2349,7 +2347,10 @@ fn setup_contracts() -> (
         oracle_address,
         swap_handler_address,
         referral_storage_address,
-        order_utils_address
+        order_utils_class_hash,
+        increase_order_class_hash,
+        decrease_order_class_hash,
+        swap_order_class_hash
     );
     let order_handler = IOrderHandlerDispatcher { contract_address: order_handler_address };
 
@@ -2579,7 +2580,10 @@ fn deploy_order_handler(
     oracle_address: ContractAddress,
     swap_handler_address: ContractAddress,
     referral_storage_address: ContractAddress,
-    order_utils_address: ContractAddress
+    order_utils_class_hash: ClassHash,
+    increase_order_class_hash: ClassHash,
+    decrease_order_class_hash: ClassHash,
+    swap_order_class_hash: ClassHash
 ) -> ContractAddress {
     let contract = declare('OrderHandler');
     let caller_address: ContractAddress = contract_address_const::<'caller'>();
@@ -2593,7 +2597,10 @@ fn deploy_order_handler(
         oracle_address.into(),
         swap_handler_address.into(),
         referral_storage_address.into(),
-        order_utils_address.into()
+        order_utils_class_hash.into(),
+        increase_order_class_hash.into(),
+        decrease_order_class_hash.into(),
+        swap_order_class_hash.into()
     ];
     contract.deploy_at(@constructor_calldata, deployed_contract_address).unwrap()
 }
@@ -2653,48 +2660,19 @@ fn deploy_order_vault(
     tests_lib::deploy_mock_contract(contract, @constructor_calldata)
 }
 
-fn deploy_increase_order() -> ContractAddress {
-    let contract = declare('IncreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'increase_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
+fn declare_increase_order() -> ClassHash {
+    declare('IncreaseOrderUtils').class_hash
 }
-fn deploy_decrease_order() -> ContractAddress {
-    let contract = declare('DecreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'decrease_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
+fn declare_decrease_order() -> ClassHash {
+    declare('DecreaseOrderUtils').class_hash
 }
-fn deploy_swap_order() -> ContractAddress {
-    let contract = declare('SwapOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'swap_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
+fn declare_swap_order() -> ClassHash {
+    declare('SwapOrderUtils').class_hash
 }
 
 
-fn deploy_order_utils(
-    increase_order_address: ContractAddress,
-    decrease_order_address: ContractAddress,
-    swap_order_address: ContractAddress,
-) -> ContractAddress {
-    let contract = declare('OrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract
-        .deploy_at(
-            @array![
-                increase_order_address.into(),
-                decrease_order_address.into(),
-                swap_order_address.into()
-            ],
-            deployed_contract_address
-        )
-        .unwrap()
+fn declare_order_utils() -> ClassHash {
+    declare('OrderUtils').class_hash
 }
 
 fn deploy_bank(

--- a/tests/integration/test_short_integration.cairo
+++ b/tests/integration/test_short_integration.cairo
@@ -600,13 +600,12 @@ fn setup_contracts() -> (
 
     let swap_handler_address = deploy_swap_handler_address(role_store_address, data_store_address);
     let referral_storage_address = deploy_referral_storage(event_emitter_address);
-    let increase_order_address = deploy_increase_order();
-    let decrease_order_address = deploy_decrease_order();
-    let swap_order_address = deploy_swap_order();
+    let increase_order_class_hash = declare_increase_order();
+    let decrease_order_class_hash = declare_decrease_order();
+    let swap_order_class_hash = declare_swap_order();
 
-    let order_utils_address = deploy_order_utils(
-        increase_order_address, decrease_order_address, swap_order_address
-    );
+    let order_utils_class_hash = declare_order_utils();
+
     let order_handler_address = deploy_order_handler(
         data_store_address,
         role_store_address,
@@ -615,7 +614,10 @@ fn setup_contracts() -> (
         oracle_address,
         swap_handler_address,
         referral_storage_address,
-        order_utils_address
+        order_utils_class_hash,
+        increase_order_class_hash,
+        decrease_order_class_hash,
+        swap_order_class_hash
     );
     let order_handler = IOrderHandlerDispatcher { contract_address: order_handler_address };
 
@@ -845,7 +847,10 @@ fn deploy_order_handler(
     oracle_address: ContractAddress,
     swap_handler_address: ContractAddress,
     referral_storage_address: ContractAddress,
-    order_utils_address: ContractAddress
+    order_utils_class_hash: ClassHash,
+    increase_order_class_hash: ClassHash,
+    decrease_order_class_hash: ClassHash,
+    swap_order_class_hash: ClassHash
 ) -> ContractAddress {
     let contract = declare('OrderHandler');
     let caller_address: ContractAddress = contract_address_const::<'caller'>();
@@ -859,7 +864,10 @@ fn deploy_order_handler(
         oracle_address.into(),
         swap_handler_address.into(),
         referral_storage_address.into(),
-        order_utils_address.into()
+        order_utils_class_hash.into(),
+        increase_order_class_hash.into(),
+        decrease_order_class_hash.into(),
+        swap_order_class_hash.into()
     ];
     contract.deploy_at(@constructor_calldata, deployed_contract_address).unwrap()
 }
@@ -919,48 +927,19 @@ fn deploy_order_vault(
     tests_lib::deploy_mock_contract(contract, @constructor_calldata)
 }
 
-fn deploy_increase_order() -> ContractAddress {
-    let contract = declare('IncreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'increase_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
+fn declare_increase_order() -> ClassHash {
+    declare('IncreaseOrderUtils').class_hash
 }
-fn deploy_decrease_order() -> ContractAddress {
-    let contract = declare('DecreaseOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'decrease_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
+fn declare_decrease_order() -> ClassHash {
+    declare('DecreaseOrderUtils').class_hash
 }
-fn deploy_swap_order() -> ContractAddress {
-    let contract = declare('SwapOrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'swap_order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract.deploy_at(@array![], deployed_contract_address).unwrap()
+fn declare_swap_order() -> ClassHash {
+    declare('SwapOrderUtils').class_hash
 }
 
 
-fn deploy_order_utils(
-    increase_order_address: ContractAddress,
-    decrease_order_address: ContractAddress,
-    swap_order_address: ContractAddress,
-) -> ContractAddress {
-    let contract = declare('OrderUtils');
-    let caller_address: ContractAddress = contract_address_const::<'caller'>();
-    let deployed_contract_address = contract_address_const::<'order_utils'>();
-    start_prank(deployed_contract_address, caller_address);
-    contract
-        .deploy_at(
-            @array![
-                increase_order_address.into(),
-                decrease_order_address.into(),
-                swap_order_address.into()
-            ],
-            deployed_contract_address
-        )
-        .unwrap()
+fn declare_order_utils() -> ClassHash {
+    declare('OrderUtils').class_hash
 }
 
 fn deploy_bank(


### PR DESCRIPTION
Use library calls in `BaseOrderHandler` in order to apply storage modifications to current contract and avoid different caller_address.
